### PR TITLE
Disable RBAC on staging site and fix plugin template path

### DIFF
--- a/configs/airflow.staging.cfg
+++ b/configs/airflow.staging.cfg
@@ -349,7 +349,7 @@ hide_paused_dags_by_default = False
 page_size = 100
 
 # Use FAB-based webserver with RBAC feature
-rbac = True
+rbac = False
 
 # Define the color of navigation bar
 navbar_color = #007A87

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -1,3 +1,5 @@
+import os
+
 from airflow import settings
 from airflow.models import dag, dagrun, taskinstance
 from airflow.models.dagbag import DagBag
@@ -65,7 +67,7 @@ admin_view_ = Dashboard(category='Dashboard Plugin', name='Dashboard View')
 
 blue_print_ = Blueprint('dashboard_plugin',
                         __name__,
-                        template_folder='/app/templates',
+                        template_folder=os.path.join(os.environ['AIRFLOW_HOME'], 'templates'),
                         static_folder='static',
                         static_url_path='/static/dashboard_plugin')
 


### PR DESCRIPTION
## Overview

This PR enables the custom admin view plugin on staging by disabling RBAC.

## Notes

Turns out when `rbac = True`, [Airflow uses an entirely different package for building its app](https://airflow.apache.org/docs/stable/plugins.html#note-on-role-based-views), which doesn't work with the plugin architecture we defined in #18. It seems like the RBAC UI will be the standard one going forward, so in the long term we may want to switch to using this UI and refactor our plugin to work with it, but for now this is the fastest way to get it working on staging.

## Testing instructions

* Make sure you can run and view that app as usual in local development
* Confirm that you can see the new plugin on staging (where I've already deployed these changes)