### PR TITLE
Add meta DAGs for cleaning up Airflow resources

### DIFF
--- a/dags/airflow_db_cleanup.py
+++ b/dags/airflow_db_cleanup.py
@@ -1,0 +1,268 @@
+"""
+A maintenance workflow that you can deploy into Airflow to periodically clean
+out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid
+having too much data in your Airflow MetaStore.
+
+Copied from https://github.com/teamclairvoyant/airflow-maintenance-dags.
+
+airflow trigger_dag --conf '{"maxDBEntryAgeInDays":30}' airflow-db-cleanup
+--conf options:
+    maxDBEntryAgeInDays:<INT> - Optional
+"""
+from airflow.models import DAG, DagRun, TaskInstance, Log, XCom, SlaMiss, \
+    DagModel, Variable
+from airflow.jobs import BaseJob
+from airflow import settings
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime, timedelta
+from sqlalchemy import func, and_
+from sqlalchemy.orm import load_only
+import os
+import logging
+import dateutil.parser
+import airflow
+
+try:
+    # airflow.utils.timezone is available from v1.10 onwards
+    from airflow.utils import timezone
+    now = timezone.utcnow
+except ImportError:
+    now = datetime.utcnow
+
+# airflow-db-cleanup
+DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")
+START_DATE = airflow.utils.dates.days_ago(1)
+# How often to Run. @daily - Once a day at Midnight (UTC)
+SCHEDULE_INTERVAL = "@daily"
+# Who is listed as the owner of this DAG in the Airflow Web Server
+DAG_OWNER_NAME = "airflow"
+# List of email address to send email alerts to if this job fails
+ALERT_EMAIL_ADDRESSES = []
+# Length to retain the log files if not already provided in the conf. If this
+# is set to 30, the job will remove those files that arE 30 days old or older.
+
+DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS = int(
+    Variable.get("airflow_db_cleanup__max_db_entry_age_in_days", 30)
+)
+# Whether the job should delete the db entries or not. Included if you want to
+# temporarily avoid deleting the db entries.
+ENABLE_DELETE = True
+# List of all the objects that will be deleted. Comment out the DB objects you
+# want to skip.
+DATABASE_OBJECTS = [
+    {
+        "airflow_db_model": DagRun,
+        "age_check_column": DagRun.execution_date,
+        "keep_last": True,
+        "keep_last_filters": [DagRun.external_trigger is False],
+        "keep_last_group_by": DagRun.dag_id},
+    {
+        "airflow_db_model": TaskInstance,
+        "age_check_column": TaskInstance.execution_date,
+        "keep_last": False,
+        "keep_last_filters": None,
+        "keep_last_group_by": None
+    },
+    {
+        "airflow_db_model": Log,
+        "age_check_column": Log.dttm,
+        "keep_last": False,
+        "keep_last_filters": None,
+        "keep_last_group_by": None
+    },
+    {
+        "airflow_db_model": XCom,
+        "age_check_column": XCom.execution_date,
+        "keep_last": False,
+        "keep_last_filters": None,
+        "keep_last_group_by": None
+    },
+    {
+        "airflow_db_model": BaseJob,
+        "age_check_column": BaseJob.latest_heartbeat,
+        "keep_last": False,
+        "keep_last_filters": None,
+        "keep_last_group_by": None
+    },
+    {
+        "airflow_db_model": SlaMiss,
+        "age_check_column": SlaMiss.execution_date,
+        "keep_last": False,
+        "keep_last_filters": None,
+        "keep_last_group_by": None
+    },
+    {
+        "airflow_db_model": DagModel,
+        "age_check_column": DagModel.last_scheduler_run,
+        "keep_last": False,
+        "keep_last_filters": None,
+        "keep_last_group_by": None
+    },
+]
+
+session = settings.Session()
+
+default_args = {
+    'owner': DAG_OWNER_NAME,
+    'depends_on_past': False,
+    'email': ALERT_EMAIL_ADDRESSES,
+    'email_on_failure': True,
+    'email_on_retry': False,
+    'start_date': START_DATE,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1)
+}
+
+dag = DAG(
+    DAG_ID,
+    default_args=default_args,
+    schedule_interval=SCHEDULE_INTERVAL,
+    start_date=START_DATE
+)
+if hasattr(dag, 'doc_md'):
+    dag.doc_md = __doc__
+if hasattr(dag, 'catchup'):
+    dag.catchup = False
+
+
+def print_configuration_function(**context):
+    logging.info("Loading Configurations...")
+    dag_run_conf = context.get("dag_run").conf
+    logging.info("dag_run.conf: " + str(dag_run_conf))
+    max_db_entry_age_in_days = None
+    if dag_run_conf:
+        max_db_entry_age_in_days = dag_run_conf.get(
+            "maxDBEntryAgeInDays", None
+        )
+    logging.info("maxDBEntryAgeInDays from dag_run.conf: " + str(dag_run_conf))
+    if (max_db_entry_age_in_days is None or max_db_entry_age_in_days < 1):
+        logging.info(
+            "maxDBEntryAgeInDays conf variable isn't included or Variable " +
+            "value is less than 1. Using Default '" +
+            str(DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS) + "'"
+        )
+        max_db_entry_age_in_days = DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS
+    max_date = now() + timedelta(-max_db_entry_age_in_days)
+    logging.info("Finished Loading Configurations")
+    logging.info("")
+
+    logging.info("Configurations:")
+    logging.info("max_db_entry_age_in_days: " + str(max_db_entry_age_in_days))
+    logging.info("max_date:                 " + str(max_date))
+    logging.info("enable_delete:            " + str(ENABLE_DELETE))
+    logging.info("session:                  " + str(session))
+    logging.info("")
+
+    logging.info("Setting max_execution_date to XCom for Downstream Processes")
+    context["ti"].xcom_push(key="max_date", value=max_date.isoformat())
+
+
+print_configuration = PythonOperator(
+    task_id='print_configuration',
+    python_callable=print_configuration_function,
+    provide_context=True,
+    dag=dag)
+
+
+def cleanup_function(**context):
+
+    logging.info("Retrieving max_execution_date from XCom")
+    max_date = context["ti"].xcom_pull(
+        task_ids=print_configuration.task_id, key="max_date"
+    )
+    max_date = dateutil.parser.parse(max_date)  # stored as iso8601 str in xcom
+
+    airflow_db_model = context["params"].get("airflow_db_model")
+    state = context["params"].get("state")
+    age_check_column = context["params"].get("age_check_column")
+    keep_last = context["params"].get("keep_last")
+    keep_last_filters = context["params"].get("keep_last_filters")
+    keep_last_group_by = context["params"].get("keep_last_group_by")
+
+    logging.info("Configurations:")
+    logging.info("max_date:                 " + str(max_date))
+    logging.info("enable_delete:            " + str(ENABLE_DELETE))
+    logging.info("session:                  " + str(session))
+    logging.info("airflow_db_model:         " + str(airflow_db_model))
+    logging.info("state:                    " + str(state))
+    logging.info("age_check_column:         " + str(age_check_column))
+    logging.info("keep_last:                " + str(keep_last))
+    logging.info("keep_last_filters:        " + str(keep_last_filters))
+    logging.info("keep_last_group_by:       " + str(keep_last_group_by))
+
+    logging.info("")
+
+    logging.info("Running Cleanup Process...")
+
+    query = session.query(airflow_db_model).options(
+        load_only(age_check_column)
+    )
+
+    logging.info("INITIAL QUERY : " + str(query))
+
+    if keep_last:
+
+        subquery = session.query(func.max(DagRun.execution_date))
+        # workaround for MySQL "table specified twice" issue
+        # https://github.com/teamclairvoyant/airflow-maintenance-dags/issues/41
+        if keep_last_filters is not None:
+            for entry in keep_last_filters:
+                subquery = subquery.filter(entry)
+
+            logging.info("SUB QUERY [keep_last_filters]: " + str(subquery))
+
+        if keep_last_group_by is not None:
+            subquery = subquery.group_by(keep_last_group_by)
+            logging.info("SUB QUERY [keep_last_group_by]: " + str(subquery))
+
+        subquery = subquery.from_self()
+
+        query = query.filter(
+            and_(age_check_column.notin_(subquery)),
+            and_(age_check_column <= max_date)
+        )
+
+    else:
+        query = query.filter(age_check_column <= max_date,)
+
+    entries_to_delete = query.all()
+
+    logging.info("Query: " + str(query))
+    logging.info(
+        "Process will be Deleting the following " +
+        str(airflow_db_model.__name__) + "(s):"
+    )
+    for entry in entries_to_delete:
+        logging.info(
+            "\tEntry: " + str(entry) + ", Date: " +
+            str(entry.__dict__[str(age_check_column).split(".")[1]])
+        )
+
+    logging.info(
+        "Process will be Deleting " + str(len(entries_to_delete)) + " " +
+        str(airflow_db_model.__name__) + "(s)"
+    )
+
+    if ENABLE_DELETE:
+        logging.info("Performing Delete...")
+        # using bulk delete
+        query.delete(synchronize_session=False)
+        session.commit()
+        logging.info("Finished Performing Delete")
+    else:
+        logging.warn("You're opted to skip deleting the db entries!!!")
+
+    logging.info("Finished Running Cleanup Process")
+
+
+for db_object in DATABASE_OBJECTS:
+
+    cleanup_op = PythonOperator(
+        task_id='cleanup_' + str(db_object["airflow_db_model"].__name__),
+        python_callable=cleanup_function,
+        params=db_object,
+        provide_context=True,
+        dag=dag
+    )
+
+    print_configuration.set_downstream(cleanup_op)

--- a/dags/airflow_log_cleanup.py
+++ b/dags/airflow_log_cleanup.py
@@ -1,0 +1,206 @@
+"""
+A maintenance workflow that you can deploy into Airflow to periodically clean
+out the task logs to avoid those getting too big.
+
+Copied from https://github.com/teamclairvoyant/airflow-maintenance-dags.
+
+airflow trigger_dag --conf '{"maxLogAgeInDays":30}' airflow-log-cleanup
+--conf options:
+    maxLogAgeInDays:<INT> - Optional
+"""
+from airflow.models import DAG, Variable
+from airflow.configuration import conf
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
+from datetime import timedelta
+import os
+import logging
+import airflow
+
+
+# airflow-log-cleanup
+DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")
+START_DATE = airflow.utils.dates.days_ago(1)
+BASE_LOG_FOLDER = conf.get("core", "BASE_LOG_FOLDER")
+# How often to Run. @daily - Once a day at Midnight
+SCHEDULE_INTERVAL = "@daily"
+# Who is listed as the owner of this DAG in the Airflow Web Server
+DAG_OWNER_NAME = "airflow"
+# List of email address to send email alerts to if this job fails
+ALERT_EMAIL_ADDRESSES = []
+# Length to retain the log files if not already provided in the conf. If this
+# is set to 30, the job will remove those files that are 30 days old or older
+DEFAULT_MAX_LOG_AGE_IN_DAYS = Variable.get(
+    "airflow_log_cleanup__max_log_age_in_days", 30
+)
+# Whether the job should delete the logs or not. Included if you want to
+# temporarily avoid deleting the logs
+ENABLE_DELETE = True
+# The number of worker nodes you have in Airflow. Will attempt to run this
+# process for however many workers there are so that each worker gets its
+# logs cleared.
+NUMBER_OF_WORKERS = 1
+DIRECTORIES_TO_DELETE = [BASE_LOG_FOLDER]
+ENABLE_DELETE_CHILD_LOG = Variable.get(
+    "airflow_log_cleanup__enable_delete_child_log", "False"
+)
+LOG_CLEANUP_PROCESS_LOCK_FILE = "/tmp/airflow_log_cleanup_worker.lock"
+logging.info("ENABLE_DELETE_CHILD_LOG  " + ENABLE_DELETE_CHILD_LOG)
+
+if not BASE_LOG_FOLDER or BASE_LOG_FOLDER.strip() == "":
+    raise ValueError(
+        "BASE_LOG_FOLDER variable is empty in airflow.cfg. It can be found "
+        "under the [core] section in the cfg file. Kindly provide an "
+        "appropriate directory path."
+    )
+
+if ENABLE_DELETE_CHILD_LOG.lower() == "true":
+    try:
+        CHILD_PROCESS_LOG_DIRECTORY = conf.get(
+            "scheduler", "CHILD_PROCESS_LOG_DIRECTORY"
+        )
+        if CHILD_PROCESS_LOG_DIRECTORY != ' ':
+            DIRECTORIES_TO_DELETE.append(CHILD_PROCESS_LOG_DIRECTORY)
+    except Exception as e:
+        logging.exception(
+            "Could not obtain CHILD_PROCESS_LOG_DIRECTORY from " +
+            "Airflow Configurations: " + str(e)
+        )
+
+default_args = {
+    'owner': DAG_OWNER_NAME,
+    'depends_on_past': False,
+    'email': ALERT_EMAIL_ADDRESSES,
+    'email_on_failure': True,
+    'email_on_retry': False,
+    'start_date': START_DATE,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1)
+}
+
+dag = DAG(
+    DAG_ID,
+    default_args=default_args,
+    schedule_interval=SCHEDULE_INTERVAL,
+    start_date=START_DATE
+)
+if hasattr(dag, 'doc_md'):
+    dag.doc_md = __doc__
+if hasattr(dag, 'catchup'):
+    dag.catchup = False
+
+start = DummyOperator(
+    task_id='start',
+    dag=dag)
+
+log_cleanup = """
+echo "Getting Configurations..."
+BASE_LOG_FOLDER="{{params.directory}}"
+WORKER_SLEEP_TIME="{{params.sleep_time}}"
+sleep ${WORKER_SLEEP_TIME}s
+MAX_LOG_AGE_IN_DAYS="{{dag_run.conf.maxLogAgeInDays}}"
+if [ "${MAX_LOG_AGE_IN_DAYS}" == "" ]; then
+    echo "maxLogAgeInDays conf variable isn't included. Using Default '""" + str(DEFAULT_MAX_LOG_AGE_IN_DAYS) + """'."
+    MAX_LOG_AGE_IN_DAYS='""" + str(DEFAULT_MAX_LOG_AGE_IN_DAYS) + """'
+fi
+ENABLE_DELETE=""" + str("true" if ENABLE_DELETE else "false") + """
+echo "Finished Getting Configurations"
+echo ""
+echo "Configurations:"
+echo "BASE_LOG_FOLDER:      '${BASE_LOG_FOLDER}'"
+echo "MAX_LOG_AGE_IN_DAYS:  '${MAX_LOG_AGE_IN_DAYS}'"
+echo "ENABLE_DELETE:        '${ENABLE_DELETE}'"
+cleanup() {
+    echo "Executing Find Statement: $1"
+    FILES_MARKED_FOR_DELETE=`eval $1`
+    echo "Process will be Deleting the following File(s)/Directory(s):"
+    echo "${FILES_MARKED_FOR_DELETE}"
+    echo "Process will be Deleting `echo "${FILES_MARKED_FOR_DELETE}" | \
+    grep -v '^$' | wc -l` File(s)/Directory(s)"     \
+    # "grep -v '^$'" - removes empty lines.
+    # "wc -l" - Counts the number of lines
+    echo ""
+    if [ "${ENABLE_DELETE}" == "true" ];
+    then
+        if [ "${FILES_MARKED_FOR_DELETE}" != "" ];
+        then
+            echo "Executing Delete Statement: $2"
+            eval $2
+            DELETE_STMT_EXIT_CODE=$?
+            if [ "${DELETE_STMT_EXIT_CODE}" != "0" ]; then
+                echo "Delete process failed with exit code \
+                    '${DELETE_STMT_EXIT_CODE}'"
+                echo "Removing lock file..."
+                rm -f """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """
+                if [ "${REMOVE_LOCK_FILE_EXIT_CODE}" != "0" ]; then
+                    echo "Error removing the lock file. \
+                    Check file permissions.\
+                    To re-run the DAG, ensure that the lock file has been \
+                    deleted (""" + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """)."
+                    exit ${REMOVE_LOCK_FILE_EXIT_CODE}
+                fi
+                exit ${DELETE_STMT_EXIT_CODE}
+            fi
+        else
+            echo "WARN: No File(s)/Directory(s) to Delete"
+        fi
+    else
+        echo "WARN: You're opted to skip deleting the File(s)/Directory(s)!!!"
+    fi
+}
+if [ ! -f """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """ ]; then
+    echo "Lock file not found on this node! \
+    Creating it to prevent collisions..."
+    touch """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """
+    CREATE_LOCK_FILE_EXIT_CODE=$?
+    if [ "${CREATE_LOCK_FILE_EXIT_CODE}" != "0" ]; then
+        echo "Error creating the lock file. \
+        Check if the airflow user can create files under tmp directory. \
+        Exiting..."
+        exit ${CREATE_LOCK_FILE_EXIT_CODE}
+    fi
+    echo ""
+    echo "Running Cleanup Process..."
+    FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type f -mtime \
+     +${MAX_LOG_AGE_IN_DAYS}"
+    DELETE_STMT="${FIND_STATEMENT} -exec rm -f {} \;"
+    cleanup "${FIND_STATEMENT}" "${DELETE_STMT}"
+    CLEANUP_EXIT_CODE=$?
+    FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type d -empty"
+    DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \;"
+    cleanup "${FIND_STATEMENT}" "${DELETE_STMT}"
+    CLEANUP_EXIT_CODE=$?
+    FIND_STATEMENT="find ${BASE_LOG_FOLDER}/* -type d -empty"
+    DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \;"
+    cleanup "${FIND_STATEMENT}" "${DELETE_STMT}"
+    CLEANUP_EXIT_CODE=$?
+    echo "Finished Running Cleanup Process"
+    echo "Deleting lock file..."
+    rm -f """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """
+    REMOVE_LOCK_FILE_EXIT_CODE=$?
+    if [ "${REMOVE_LOCK_FILE_EXIT_CODE}" != "0" ]; then
+        echo "Error removing the lock file. Check file permissions. To re-run the DAG, ensure that the lock file has been deleted (""" + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """)."
+        exit ${REMOVE_LOCK_FILE_EXIT_CODE}
+    fi
+else
+    echo "Another task is already deleting logs on this worker node. \
+    Skipping it!"
+    echo "If you believe you're receiving this message in error, kindly check \
+    if """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """ exists and delete it."
+    exit 0
+fi
+"""
+
+for log_cleanup_id in range(1, NUMBER_OF_WORKERS + 1):
+
+    for dir_id, directory in enumerate(DIRECTORIES_TO_DELETE):
+
+        log_cleanup_op = BashOperator(
+            task_id='log_cleanup_worker_num_' + str(log_cleanup_id) + '_dir_' + str(dir_id),
+            bash_command=log_cleanup,
+            params={
+                "directory": str(directory),
+                "sleep_time": int(log_cleanup_id)*3},
+            dag=dag)
+
+        log_cleanup_op.set_upstream(start)

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -29,7 +29,8 @@ class Dashboard(BaseView):
         session = settings.Session()
         bag = DagBag()
         all_dag_ids = bag.dag_ids
-        all_dags = [bag.get_dag(dag_id) for dag_id in all_dag_ids]
+        all_dags = [bag.get_dag(dag_id) for dag_id in all_dag_ids
+                    if not dag_id.startswith('airflow_')]  # Filter meta-DAGs
 
         dag_info = self.get_dag_info(all_dags, session)
 


### PR DESCRIPTION
## Overview

Following the advice in https://blog.clairvoyantsoft.com/automated-maintenance-for-apache-airflow-8d844f32737d, this PR defines two meta-DAGs, `airflow_db_cleanup` and `airflow_log_cleanup`, that run daily and clean up old logs and database entries for the app.

## Notes

As part of debugging for this PR, I also manually deleted about 4 GB of logs from the staging server. This should give us enough room to cover us while we review and deploy this change.

## Testing instructions

* Start the LA Metro server in the background: `cd la-metro-councilmatic && docker-compose up -d app`
* Start the dashboard server: `cd ../la-metro-dashboard && docker-compose up`
* Navigate to http://localhost:8080 and turn `ON` both `airflow_log_cleanup` and `airflow_db_cleanup`
* After `airflow_log_cleanup` and `airflow_db_cleanup` have run, check their log output to confirm that they deleted logs and database tables older than 30 days
    * If you don't have logs or database tables older than 30 days, you can also manually trigger these DAGs and set the config attribute `maxDBEntryAgeInDays` or `maxLogAgeInDays` to make the window smaller (e.g. a complete config object might look like `{"maxDBEntryAgeInDays": 7}` )