### PR TITLE
Fix next DAG run

### DIFF
--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -116,11 +116,17 @@ class Dashboard(BaseView):
         return data
 
     def get_last_successful_dagrun(self, dags):
-        last = max(dags, key=lambda x: x['last_successful_date']['pst_time'])
+        last = max(
+            dag for dag in dags if dag['last_successful_date']['pst_time'],
+            key=lambda x: x['last_successful_date']['pst_time']
+        )
         return last['last_successful'], last['last_successful_date']
 
     def get_next_dagrun(self, dags):
-        return min(dags, key=lambda x: x['next_scheduled']['pst_time'])
+        return min(
+            dag for dag in dags if dag['last_successful_date']['pst_time'],
+            key=lambda x: x['next_scheduled']['pst_time']
+        )
 
     def get_db_info(self):
         url_parts = {

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -201,10 +201,10 @@ class Dashboard(BaseView):
         DagRun.
         """
         return self.AIRFLOW_SESSION.query(dagrun.DagRun)\
-                      .filter(dagrun.DagRun.dag_id == dag_id)\
-                      .filter(dagrun.DagRun.state == 'success')\
-                      .order_by(dagrun.DagRun.execution_date.desc())\
-                      .first()
+                                   .filter(dagrun.DagRun.dag_id == dag_id)\
+                                   .filter(dagrun.DagRun.state == 'success')\
+                                   .order_by(dagrun.DagRun.execution_date.desc())\
+                                   .first()
 
 
 dashboard_package = {

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -116,18 +116,20 @@ class Dashboard(BaseView):
         return data
 
     def get_last_successful_dagrun(self, dags):
-        try:
-            last = max(
-                (dag for dag in dags if dag['last_successful_date']['pst_time']),
-                key=lambda x: x['last_successful_date']['pst_time']
-            )
-        except:
-            raise Exception(dags)
+        import pprint
+        pprint.pprint(dags)
+        pprint.pprint(list(dag for dag in dags if dag['last_successful_date']['pst_time'] is not None))
+
+        last = max(
+            (dag for dag in dags if dag['last_successful_date']['pst_time'] is not None),
+            key=lambda x: x['last_successful_date']['pst_time']
+        )
+
         return last['last_successful'], last['last_successful_date']
 
     def get_next_dagrun(self, dags):
         return min(
-            (dag for dag in dags if dag['next_scheduled']['pst_time']),
+            (dag for dag in dags if dag['next_scheduled']['pst_time'] is not None),
             key=lambda x: x['next_scheduled']['pst_time']
         )
 

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -116,10 +116,13 @@ class Dashboard(BaseView):
         return data
 
     def get_last_successful_dagrun(self, dags):
-        last = max(
-            (dag for dag in dags if dag['last_successful_date']['pst_time']),
-            key=lambda x: x['last_successful_date']['pst_time']
-        )
+        try:
+            last = max(
+                (dag for dag in dags if dag['last_successful_date']['pst_time']),
+                key=lambda x: x['last_successful_date']['pst_time']
+            )
+        except:
+            raise Exception(dags)
         return last['last_successful'], last['last_successful_date']
 
     def get_next_dagrun(self, dags):

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -117,14 +117,14 @@ class Dashboard(BaseView):
 
     def get_last_successful_dagrun(self, dags):
         last = max(
-            dag for dag in dags if dag['last_successful_date']['pst_time'],
+            (dag for dag in dags if dag['last_successful_date']['pst_time']),
             key=lambda x: x['last_successful_date']['pst_time']
         )
         return last['last_successful'], last['last_successful_date']
 
     def get_next_dagrun(self, dags):
         return min(
-            dag for dag in dags if dag['last_successful_date']['pst_time'],
+            (dag for dag in dags if dag['next_scheduled']['pst_time']),
             key=lambda x: x['next_scheduled']['pst_time']
         )
 

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -67,6 +67,7 @@ class Dashboard(BaseView):
             'bill_next_run': bill_next_run,
             'bills_in_db': bills_in_db,
             'bills_in_index': bills_in_index,
+            'datetime_format': self.DATETIME_FORMAT,
         }
 
         return self.render_template('dashboard.html', **metadata)
@@ -94,12 +95,12 @@ class Dashboard(BaseView):
 
             else:
                 run_state = None
-                run_date_info = self._get_localized_time(None)
+                run_date_info = {}
 
                 last_successful = None
-                last_successful_info = self._get_localized_time(None)
+                last_successful_info = {}
 
-                next_scheduled_info = self._get_localized_time(None)
+                next_scheduled_info = {}
 
             dag_info = {
                 'name': d.dag_id,
@@ -116,12 +117,8 @@ class Dashboard(BaseView):
         return data
 
     def get_last_successful_dagrun(self, dags):
-        import pprint
-        pprint.pprint(dags)
-        pprint.pprint(list(dag for dag in dags if dag['last_successful_date']['pst_time'] is not None))
-
         last = max(
-            (dag for dag in dags if dag['last_successful_date']['pst_time'] is not None),
+            (dag for dag in dags if dag['last_successful_date'].get('pst_time')),
             key=lambda x: x['last_successful_date']['pst_time']
         )
 
@@ -129,7 +126,7 @@ class Dashboard(BaseView):
 
     def get_next_dagrun(self, dags):
         return min(
-            (dag for dag in dags if dag['next_scheduled']['pst_time'] is not None),
+            (dag for dag in dags if dag['next_scheduled'].get('pst_time')),
             key=lambda x: x['next_scheduled']['pst_time']
         )
 
@@ -158,12 +155,8 @@ class Dashboard(BaseView):
         return None, None, None
 
     def _get_localized_time(self, date):
-        if date:
-            pst_time = datetime.strftime(date.astimezone(PACIFIC_TIMEZONE), self.DATETIME_FORMAT)
-            cst_time = datetime.strftime(date.astimezone(CENTRAL_TIMEZONE), self.DATETIME_FORMAT)
-
-        else:
-            pst_time, cst_time = None, None
+        pst_time = date.astimezone(PACIFIC_TIMEZONE)
+        cst_time = date.astimezone(CENTRAL_TIMEZONE)
 
         return {
             'pst_time': pst_time,
@@ -180,7 +173,7 @@ class Dashboard(BaseView):
         if run:
             run_time = self._get_localized_time(run.execution_date)
         else:
-            run_time = self._get_localized_time(None)
+            run_time = {}
 
         return (run, run_time)
 

--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -95,8 +95,6 @@ class Dashboard(BaseView):
                 next_scheduled = d.following_schedule(datetime.now(pytz.utc))
                 next_scheduled_info = self._get_localized_time(next_scheduled)
 
-                print(next_scheduled_info)
-
             else:
                 run_state = None
 

--- a/plugins/templates/dashboard.html
+++ b/plugins/templates/dashboard.html
@@ -126,8 +126,8 @@
             <tr>
               <th class='column-header'>Name</th>
               <th class='column-header text-center'>Most Recent Run Status</th>
-              <th class='column-header text-right'>Most Recent Run Date</th>
-              <th class='column-header text-right'>Next Scheduled Run Date</th>
+              <th class='column-header'>Most Recent Run Date</th>
+              <th class='column-header'>Next Scheduled Run Date</th>
             </tr>
           </thead>
 

--- a/plugins/templates/dashboard.html
+++ b/plugins/templates/dashboard.html
@@ -23,11 +23,11 @@
             </thead>
             <tr>
               <td>
-                {{ bill_last_run.dag_id }}
+                {{ bill_last_run.name }}
               </td>
               <td>
-                {{ bill_last_run_time.pst_time.strftime(datetime_format) }} PST<br />
-                {{ bill_last_run_time.cst_time.strftime(datetime_format) }} CST
+                {{ bill_last_run.last_successful_date.pst_time.strftime(datetime_format) }} PST<br />
+                {{ bill_last_run.last_successful_date.cst_time.strftime(datetime_format) }} CST
               </td>
             </tr>
           </table>
@@ -47,8 +47,8 @@
                   {{ bill_next_run.name }}
                 </td>
                 <td>
-                  {{ bill_next_run.next_scheduled.pst_time.strftime(datetime_format) }} PST<br />
-                  {{ bill_next_run.next_scheduled.cst_time.strftime(datetime_format) }} CST
+                  {{ bill_next_run.next_scheduled_date.pst_time.strftime(datetime_format) }} PST<br />
+                  {{ bill_next_run.next_scheduled_date.cst_time.strftime(datetime_format) }} CST
                 </td>
               </tr>
             </table>
@@ -75,11 +75,11 @@
             </thead>
             <tr>
               <td>
-                {{ event_last_run.dag_id }}
+                {{ event_last_run.name }}
               </td>
               <td>
-                {{ event_last_run_time.pst_time.strftime(datetime_format) }} PST<br />
-                {{ event_last_run_time.cst_time.strftime(datetime_format) }} CST
+                {{ event_last_run.last_successful_date.pst_time.strftime(datetime_format) }} PST<br />
+                {{ event_last_run.last_successful_date.cst_time.strftime(datetime_format) }} CST
               </td>
             </tr>
           </table>
@@ -99,8 +99,8 @@
                   {{ event_next_run.name }}
                 </td>
                 <td>
-                  {{ event_next_run.next_scheduled.pst_time.strftime(datetime_format) }} PST<br />
-                  {{ event_next_run.next_scheduled.cst_time.strftime(datetime_format) }} CST
+                  {{ event_next_run.next_scheduled_date.pst_time.strftime(datetime_format) }} PST<br />
+                  {{ event_next_run.next_scheduled_date.cst_time.strftime(datetime_format) }} CST
                 </td>
               </tr>
             </table>
@@ -152,8 +152,8 @@
               {% else %}
                 <td></td>
               {% endif %}
-              {% if dag.next_scheduled %}
-                <td>{{ dag.next_scheduled.pst_time.strftime(datetime_format) }} PST<br /> {{ dag.next_scheduled.cst_time.strftime(datetime_format) }} CST</td>
+              {% if dag.next_scheduled_date.pst_time %}
+                <td>{{ dag.next_scheduled_date.pst_time.strftime(datetime_format) }} PST<br /> {{ dag.next_scheduled_date.cst_time.strftime(datetime_format) }} CST</td>
               {% else %}
                 <td></td>
               {% endif %}

--- a/plugins/templates/dashboard.html
+++ b/plugins/templates/dashboard.html
@@ -3,30 +3,59 @@
 {% block title %}LA Metro ETL Dashboard{% endblock %}
 
 {% block content %}
-  <h2>LA Metro Board Agendas ETL Dashboard</h2>
   <div class='container'>
     <div class='row'>
+      <h2>LA Metro Board Agendas ETL Dashboard</h2>
+
       <div class='col-sm-6'>
         <div style='margin-bottom: 1em'>
           <h4>
             <i class="fa fa-book"></i>
-            Bills ({{ bills_in_db }} Total)
+            Bills <small>{{ bills_in_db }} in database, {{ bills_in_index }} in search index</small>
           </h4>
-          <li><strong>Last Successful Bill Run: </strong>
-            {% if bill_last_run %}
-              {{ bill_last_run.dag_id }} at {{ bill_last_run_time.pst_time }} PST ({{ bill_last_run_time.cst_time }} CST)
-            {% else %}
-              No Bill Scrapes Completed
-            {% endif %}
-          </li>
-          <li><strong>Upcoming Bill Run: </strong>
-            {% if bill_next_run %}
-              {{ bill_next_run.name }} at {{ bill_next_run.next_scheduled.pst_time }} PST ({{ bill_next_run.next_scheduled.cst_time }} CST)
-            {% else %}
-              No Bill Scrapes Scheduled
-            {% endif %}
-          </li>
-          <li><strong>Bills in Search Index: </strong>{{ bills_in_index }}</li>
+
+          <strong>Last Successful Bill Run</strong><br />
+          {% if bill_last_run %}
+          <table class="table table-sm">
+            <thead>
+              <th>DAG</th>
+              <th>Time</th>
+            </thead>
+            <tr>
+              <td>
+                {{ bill_last_run.dag_id }}
+              </td>
+              <td>
+                {{ bill_last_run_time.pst_time.strftime(datetime_format) }} PST<br />
+                {{ bill_last_run_time.cst_time.strftime(datetime_format) }} CST
+              </td>
+            </tr>
+          </table>
+          {% else %}
+            No Bill Scrapes Completed
+          {% endif %}
+
+          <strong>Upcoming Bill Run</strong><br />
+          {% if bill_next_run %}
+            <table class="table table-sm">
+              <thead>
+                <th>DAG</th>
+                <th>Time</th>
+              </thead>
+              <tr>
+                <td>
+                  {{ bill_next_run.name }}
+                </td>
+                <td>
+                  {{ bill_next_run.next_scheduled.pst_time.strftime(datetime_format) }} PST<br />
+                  {{ bill_next_run.next_scheduled.cst_time.strftime(datetime_format) }} CST
+                </td>
+              </tr>
+            </table>
+          {% else %}
+            No Bill Scrapes Scheduled
+          {% endif %}
+
         </div>
       </div>
 
@@ -34,70 +63,108 @@
         <div style='margin-bottom: 1em'>
           <h4>
             <i class="fa fa-calendar"></i>
-            Events ({{ events_in_db }} Total)
+            Events <small>{{ events_in_db }} in database</small>
           </h4>
-          <li><strong>Last Successful Event Run: </strong>
-            {% if event_last_run %}
-              {{ event_last_run.dag_id }} at {{ event_last_run_time.pst_time }} PST ({{ event_last_run_time.cst_time }} CST)
-            {% else %}
-              No Event Scrapes Completed
-            {% endif %}
-          </li>
-          <li><strong>Upcoming Event Run: </strong>
-            {% if event_next_run %}
-              {{ event_next_run.name }} at {{ event_next_run.next_scheduled.pst_time }} PST ({{ event_next_run.next_scheduled.cst_time }} CST)
-            {% else %}
-              No Event Scrapes Scheduled
-            {% endif %}
-          </li>
+
+          <strong>Last Successful Event Run</strong><br />
+          {% if event_last_run %}
+            <table class="table table-sm">
+            <thead>
+              <th>DAG</th>
+              <th>Time</th>
+            </thead>
+            <tr>
+              <td>
+                {{ event_last_run.dag_id }}
+              </td>
+              <td>
+                {{ event_last_run_time.pst_time.strftime(datetime_format) }} PST<br />
+                {{ event_last_run_time.cst_time.strftime(datetime_format) }} CST
+              </td>
+            </tr>
+          </table>
+          {% else %}
+            No Event Scrapes Completed
+          {% endif %}
+
+          <strong>Upcoming Event Run</strong><br />
+          {% if event_next_run %}
+            <table class="table table-sm">
+              <thead>
+                <th>DAG</th>
+                <th>Time</th>
+              </thead>
+              <tr>
+                <td>
+                  {{ event_next_run.name }}
+                </td>
+                <td>
+                  {{ event_next_run.next_scheduled.pst_time.strftime(datetime_format) }} PST<br />
+                  {{ event_next_run.next_scheduled.cst_time.strftime(datetime_format) }} CST
+                </td>
+              </tr>
+            </table>
+          {% else %}
+            No Event Scrapes Scheduled
+          {% endif %}
         </div>
       </div>
+
+    </div><!-- end .row -->
+
+    <hr class="m-3" />
+
+    {% block model_list_table %}
+    <div class="row">
+      <div class="col-sm-12">
+        <h4>
+          <i class="fa fa-table"></i>
+          Job Overview
+        </h4>
+        <table class='table table-striped table-bordered table-hover model-list' id='dashboard-table'>
+          <thead>
+            <tr>
+              <th class='column-header'>Name</th>
+              <th class='column-header text-center'>Most Recent Run Status</th>
+              <th class='column-header text-right'>Most Recent Run Date</th>
+              <th class='column-header text-right'>Next Scheduled Run Date</th>
+            </tr>
+          </thead>
+
+          {% for dag in data %}
+            <tr>
+              <td>
+                <strong>{{ dag.name }}</strong>
+                <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="top" title="{{ dag.description }}"></i>
+              </td>
+              {% if dag.run_state == 'failed' %}
+                <td class="text-center"><span style="color: red"><i class="fa fa-times-circle"></i><br />Failed</span></td>
+              {% elif dag.run_state == 'success' %}
+                <td class="text-center"><span style="color: green"><i class="fa fa-check-circle"></i><br />Succeeded</span></td>
+              {% elif dag.run_state == 'running' %}
+                <td class="text-center"><i class="fa fa-spinner fa-spin"></i><br />Running</td>
+              {% else %}
+                <td class="text-center">{{ dag.run_state or '' }}</td>
+              {% endif %}
+
+              {% if dag.run_date.pst_time %}
+                <td>{{ dag.run_date.pst_time.strftime(datetime_format) }} PST<br /> {{ dag.run_date.cst_time.strftime(datetime_format) }} CST</td>
+              {% else %}
+                <td></td>
+              {% endif %}
+              {% if dag.next_scheduled %}
+                <td>{{ dag.next_scheduled.pst_time.strftime(datetime_format) }} PST<br /> {{ dag.next_scheduled.cst_time.strftime(datetime_format) }} CST</td>
+              {% else %}
+                <td></td>
+              {% endif %}
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
     </div>
-  </div>
-  <br />
-  <br />
+    {% endblock %}
 
-  {% block model_list_table %}
-    <table class='table table-striped table-bordered table-hover model-list' id='dashboard-table'>
-      <thead>
-        <tr>
-          <th class='column-header'>Name</th>
-          <th class='column-header text-center'>Most Recent Run Status</th>
-          <th class='column-header text-right'>Most Recent Run Date</th>
-          <th class='column-header text-right'>Next Scheduled Run Date</th>
-        </tr>
-      </thead>
-
-      {% for dag in data %}
-        <tr>
-          <td>
-            <strong>{{ dag.name }}</strong>
-            <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="top" title="{{ dag.description }}"></i>
-          </td>
-          {% if dag.run_state == 'failed' %}
-            <td class="text-center"><span style="color: red"><i class="fa fa-times-circle"></i><br />Failed</span></td>
-          {% elif dag.run_state == 'success' %}
-            <td class="text-center"><span style="color: green"><i class="fa fa-check-circle"></i><br />Succeeded</span></td>
-          {% elif dag.run_state == 'running' %}
-            <td class="text-center"><i class="fa fa-spinner fa-spin"></i><br />Running</td>
-          {% else %}
-            <td class="text-center">{{ dag.run_state or '' }}</td>
-          {% endif %}
-
-          {% if dag.run_date != None %}
-            <td class="text-right">{{ dag.run_date.pst_time }} PST<br /> {{ dag.run_date.cst_time }} CST</td>
-          {% else %}
-            <td class="text-right"></td>
-          {% endif %}
-          {% if dag.next_scheduled != None %}
-            <td class="text-right">{{ dag.next_scheduled.pst_time }} PST<br /> {{ dag.next_scheduled.cst_time }} CST</td>
-          {% else %}
-            <td class="text-right"></td>
-          {% endif %}
-        </tr>
-      {% endfor %}
-    </table>
-  {% endblock %}
+  </div><!-- end .container -->
 {% endblock %}
 
 {% block tail_js %}

--- a/plugins/templates/dashboard.html
+++ b/plugins/templates/dashboard.html
@@ -12,7 +12,7 @@
             <i class="fa fa-book"></i>
             Bills ({{ bills_in_db }} Total)
           </h4>
-          <li><strong>Last Bill Run: </strong>
+          <li><strong>Last Successful Bill Run: </strong>
             {% if bill_last_run %}
               {{ bill_last_run.dag_id }} at {{ bill_last_run_time.pst_time }} PST ({{ bill_last_run_time.cst_time }} CST)
             {% else %}
@@ -36,7 +36,7 @@
             <i class="fa fa-calendar"></i>
             Events ({{ events_in_db }} Total)
           </h4>
-          <li><strong>Last Event Run: </strong>
+          <li><strong>Last Successful Event Run: </strong>
             {% if event_last_run %}
               {{ event_last_run.dag_id }} at {{event_last_run_time.pst_time }} PST ({{ bill_last_run_time.cst_time }} CST)
             {% else %}

--- a/plugins/templates/dashboard.html
+++ b/plugins/templates/dashboard.html
@@ -38,7 +38,7 @@
           </h4>
           <li><strong>Last Successful Event Run: </strong>
             {% if event_last_run %}
-              {{ event_last_run.dag_id }} at {{event_last_run_time.pst_time }} PST ({{ bill_last_run_time.cst_time }} CST)
+              {{ event_last_run.dag_id }} at {{ event_last_run_time.pst_time }} PST ({{ event_last_run_time.cst_time }} CST)
             {% else %}
               No Event Scrapes Completed
             {% endif %}
@@ -57,15 +57,14 @@
   <br />
   <br />
 
-
   {% block model_list_table %}
     <table class='table table-striped table-bordered table-hover model-list' id='dashboard-table'>
       <thead>
         <tr>
           <th class='column-header'>Name</th>
-          <th class='column-header'>Most Recent Run Status</th>
-          <th class='column-header'>Most Recent Run Date</th>
-          <th class='column-header'>Next Scheduled</th>
+          <th class='column-header text-center'>Most Recent Run Status</th>
+          <th class='column-header text-right'>Most Recent Run Date</th>
+          <th class='column-header text-right'>Next Scheduled Run Date</th>
         </tr>
       </thead>
 
@@ -86,14 +85,14 @@
           {% endif %}
 
           {% if dag.run_date != None %}
-            <td>{{ dag.run_date.pst_time }} PST<br /> {{ dag.run_date.cst_time }} CST</td>
+            <td class="text-right">{{ dag.run_date.pst_time }} PST<br /> {{ dag.run_date.cst_time }} CST</td>
           {% else %}
-            <td></td>
+            <td class="text-right"></td>
           {% endif %}
           {% if dag.next_scheduled != None %}
-            <td>{{ dag.next_scheduled.pst_time }} PST<br /> {{ dag.next_scheduled.cst_time }} CST</td>
+            <td class="text-right">{{ dag.next_scheduled.pst_time }} PST<br /> {{ dag.next_scheduled.cst_time }} CST</td>
           {% else %}
-            <td></td>
+            <td class="text-right"></td>
           {% endif %}
         </tr>
       {% endfor %}


### PR DESCRIPTION
### Description

This PR breaks the long `list()` method in the dashboard plugin into several helper functions for legibility, then repurposes some existing code to retrieve the last successful run in the `get_dag_info` loop. The vast majority of this PR is moving code around. I've marked new code with inline comments. Handles #34, also patches bug where the wrong Central time was displayed for the last event run.

### Testing

- Visit the staging dashboard and confirm the next DAG run is shown as expected at the top (and matches the corresponding row in the table).
  - Note that I have toggled off `hourly_processing` due to continued failures I need to debug, as well as `daily_scraping` as it seems to be contributing to increased timeouts for our live scrapers, so the last run for those DAGs is a few days ago.