### PR TITLE
Set a static start date

### DIFF
--- a/dags/constants.py
+++ b/dags/constants.py
@@ -1,5 +1,8 @@
+from datetime import datetime
 import os
 
+
+START_DATE = datetime(2020, 7, 15)
 
 # Configure DAG container to connect to specific Docker network, useful for
 # local development (not necessary in production)

--- a/dags/daily_scraping.py
+++ b/dags/daily_scraping.py
@@ -1,14 +1,15 @@
+from datetime import timedelta
 import os
-from datetime import datetime, timedelta
 
 from airflow import DAG
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(hours=12),
     'image': 'datamade/scrapers-us-municipal:staging',
     'environment': {

--- a/dags/friday_hourly_scraping.py
+++ b/dags/friday_hourly_scraping.py
@@ -1,5 +1,5 @@
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator

--- a/dags/friday_hourly_scraping.py
+++ b/dags/friday_hourly_scraping.py
@@ -1,15 +1,16 @@
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(hours=1),
 }
 

--- a/dags/hourly_processing.py
+++ b/dags/hourly_processing.py
@@ -3,12 +3,13 @@ import os
 
 from airflow import DAG
 
-from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_SOLR_URL, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_SOLR_URL, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(minutes=15),
     'image': 'datamade/la-metro-councilmatic:staging',
     'environment': {

--- a/dags/refresh_guid.py
+++ b/dags/refresh_guid.py
@@ -3,12 +3,13 @@ import os
 
 from airflow import DAG
 
-from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_SOLR_URL, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_SOLR_URL, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(minutes=5),
     'image': 'datamade/la-metro-councilmatic:staging',
     'environment': {

--- a/dags/saturday_hourly_scraping.py
+++ b/dags/saturday_hourly_scraping.py
@@ -1,5 +1,5 @@
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator

--- a/dags/saturday_hourly_scraping.py
+++ b/dags/saturday_hourly_scraping.py
@@ -1,15 +1,16 @@
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(hours=1),
 }
 

--- a/dags/windowed_bill_scraping.py
+++ b/dags/windowed_bill_scraping.py
@@ -5,12 +5,13 @@ from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(hours=3)
 }
 

--- a/dags/windowed_event_scraping.py
+++ b/dags/windowed_event_scraping.py
@@ -5,12 +5,13 @@ from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
 default_args = {
-    'start_date': datetime.now() - timedelta(hours=1),
+    'start_date': START_DATE,
     'execution_timeout': timedelta(hours=3)
 }
 


### PR DESCRIPTION
## Description

This PR sets a static start date for all of our DAGs. The reasoning behind this change is outlined in https://github.com/datamade/la-metro-dashboard/issues/37#issuecomment-661112215.

## Testing instructions

- I am going to manually deploy this and take lunch. I'll check to see whether our scheduled DAGs were able to run during that time, then request review pending success.