### PR TITLE
Set default DB entry and log max age to 14 for cleanup

### DIFF
--- a/dags/airflow_db_cleanup.py
+++ b/dags/airflow_db_cleanup.py
@@ -42,7 +42,7 @@ ALERT_EMAIL_ADDRESSES = []
 # is set to 30, the job will remove those files that arE 30 days old or older.
 
 DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS = int(
-    Variable.get("airflow_db_cleanup__max_db_entry_age_in_days", 30)
+    Variable.get("airflow_db_cleanup__max_db_entry_age_in_days", 14)
 )
 # Whether the job should delete the db entries or not. Included if you want to
 # temporarily avoid deleting the db entries.

--- a/dags/airflow_log_cleanup.py
+++ b/dags/airflow_log_cleanup.py
@@ -31,7 +31,7 @@ ALERT_EMAIL_ADDRESSES = []
 # Length to retain the log files if not already provided in the conf. If this
 # is set to 30, the job will remove those files that are 30 days old or older
 DEFAULT_MAX_LOG_AGE_IN_DAYS = Variable.get(
-    "airflow_log_cleanup__max_log_age_in_days", 30
+    "airflow_log_cleanup__max_log_age_in_days", 14
 )
 # Whether the job should delete the logs or not. Included if you want to
 # temporarily avoid deleting the logs


### PR DESCRIPTION
## Overview

This PR updates the default max age for logs and DB entries to 14 days, down from 30 days. This change should help address #36 by more aggressively cleaning up logs.

Connects https://github.com/datamade/server-la-metro-dashboard/pull/5, #36 

## Testing instructions

* Visit http://localhost:8080/tree?dag_id=airflow_db_cleanup and http://localhost:8080/tree?dag_id=airflow_log_cleanup
* Trigger both DAGs
* Check the logs for the most recent DAG runs
* Confirm that the config log printed a `MAX_LOG_AGE_IN_DAYS` value of `14`