### PR TITLE
Remove container, even if the command fails

### DIFF
--- a/operators/blackbox_docker_operator.py
+++ b/operators/blackbox_docker_operator.py
@@ -44,6 +44,7 @@ class BlackboxDockerOperator(DockerOperator):
             return super()._run_image()
 
         except AirflowException as e:
-            self.cli.remove_container(self.container['Id'])
+            if self.auto_remove:
+                self.cli.remove_container(self.container['Id'])
 
             raise e


### PR DESCRIPTION
## Description

This PR extends the `_run_image` method of the `DockerOperator` to remove the container, even if the command fails. Handles https://github.com/datamade/la-metro-dashboard/issues/36#issuecomment-667213537

## Testing instruction

- I've run a DAG with a task that I know will fail and confirmed that all containers associated with the DAG are cleaned up.
- Double check that this approach makes sense.
- I'll monitor the staging site after we bring this change in.