### PR TITLE
Reread configs and explicitly start application and scheduler containers

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -4,6 +4,9 @@ files:
  - source: /
    destination: /home/datamade/la-metro-dashboard-deployment-root
 hooks:
+  ApplicationStop:
+  - location: scripts/app_stop.sh
+    runas: root
  BeforeInstall:
   - location: scripts/before_install.sh
     runas: root

--- a/appspec.yml
+++ b/appspec.yml
@@ -7,12 +7,12 @@ hooks:
   ApplicationStop:
   - location: scripts/app_stop.sh
     runas: root
- BeforeInstall:
+  BeforeInstall:
   - location: scripts/before_install.sh
     runas: root
- ApplicationStart:
+  ApplicationStart:
   - location: scripts/app_start.sh
     runas: root
- AfterInstall:
+  AfterInstall:
   - location: scripts/after_install.sh
     runas: root

--- a/scripts/app_start.sh
+++ b/scripts/app_start.sh
@@ -7,7 +7,8 @@ source ${BASH_SOURCE%/*}/../configs/$DEPLOYMENT_GROUP_NAME-config.conf
 
 # Re-read supervisor config, and add new processes
 echo "Reloading supervisor"
-supervisorctl update $APP_NAME $APP_NAME-scheduler
+supervisorctl reread $APP_NAME $APP_NAME-scheduler
+supervisorctl start $APP_NAME $APP_NAME-scheduler
 
 echo "Reloading nginx"
 nginx -t


### PR DESCRIPTION
## Description

This PR:

- Adds the missing `ApplicationStop` hook so the dashboard and scheduler processes are stopped.
- Uses `supervisor reread` to recognize configuration changes, then starts the application and scheduler processes explicitly to capture code changes.

Closes #44.

## Notes

`reread`, `reload`, `restart`, and `update` can be confusing! This is the best explanation I have found: https://github.com/Supervisor/supervisor/issues/720#issuecomment-359222022

The docs also offer some clarification: http://supervisord.org/running.html

`update` only restarts services whose configurations have changed – we want everything to restart on deployment. So, the full flow here is to `stop` the services in `app_stop.sh`, then `reread` configs and `start` the services in `app_start.sh`. I chose `reread` vs. `update` because we have to explicitly `start` the services, so any `restart`s based on config changes via `update` would be redundant with the explicit `start`. 

## Testing

I manually triggered [a deployment](https://console.aws.amazon.com/codesuite/codedeploy/deployments/d-ZBOEG2TQ5?region=us-east-1), confirmed it succeeded, and confirmed that the Supervisor processes had only been up for a few seconds:

```bash
ubuntu@ip-10-0-0-244:~$ sudo supervisorctl status
la-metro-dashboard               RUNNING   pid 5589, uptime 0:00:28
la-metro-dashboard-scheduler     RUNNING   pid 5593, uptime 0:00:27
```