### PR TITLE
Extend full scrape to populate staging database

### DIFF
--- a/dags/constants.py
+++ b/dags/constants.py
@@ -23,6 +23,7 @@ AIRFLOW_DIR_PATH = os.getenv(
 
 # Configure connection strings for the Metro database and Solr index
 LA_METRO_DATABASE_URL = os.getenv('LA_METRO_DATABASE_URL', 'postgres://postgres:postgres@postgres:5432/lametro')
+LA_METRO_STAGING_DATABASE_URL = os.getenv('LA_METRO_STAGING_DATABASE_URL', '')
 LA_METRO_SOLR_URL = os.getenv('LA_METRO_SOLR_URL', 'http://solr:8983/solr/lametro')
 
 DAG_DESCRIPTIONS = {

--- a/dags/daily_scraping.py
+++ b/dags/daily_scraping.py
@@ -3,8 +3,8 @@ import os
 
 from airflow import DAG
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
-    DAG_DESCRIPTIONS, START_DATE
+from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_STAGING_DATABASE_URL, \
+    AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -17,6 +17,7 @@ default_args = {
         'DESTINATION_SETTINGS': 'pupa_settings.py',
         'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
         'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+        'LA_METRO_STAGING_DATABASE_URL': LA_METRO_STAGING_DATABASE_URL,
     },
     'volumes': [
         '{}:/app/scraper_scripts'.format(os.path.join(AIRFLOW_DIR_PATH, 'dags', 'scripts'))

--- a/dags/scripts/full-scrape.sh
+++ b/dags/scripts/full-scrape.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 set -e
 
-import_to_staging() {
-    # If the database URL does not contain "staging", it's the production
-    # database. Append "_staging" and import. Assumes that the staging and
-    # production databases live on the same server, and follow the naming
-    # convention "${DATABASE_NAME}" and "${DATABASE_NAME}_staging".
-    if [[ "$DATABASE_URL" != *"staging"* ]]; then
-        STAGING_DATABASE_URL="${LA_METRO_DATABASE_URL}_staging"
-        echo "Importing into staging database ${STAGING_DATABASE_URL}"
-        SHARED_DB=True DATABASE_URL=$STAGING_DATABASE_URL pupa update lametro --import || echo "${STAGING_DATABASE_URL} does not exist"
+conditionally_import_to_staging() {
+    if [[ -n "$LA_METRO_STAGING_DATABASE_URL" ]]; then
+        echo "Importing into staging database ${LA_METRO_STAGING_DATABASE_URL}"
+        SHARED_DB=True DATABASE_URL=$LA_METRO_STAGING_DATABASE_URL pupa update lametro --import || echo "${LA_METRO_STAGING_DATABASE_URL} does not exist"
     fi
 }
 
@@ -17,9 +12,9 @@ import_to_staging() {
 # windowed bills.
 pupa update lametro --scrape
 SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
-import_to_staging
+conditionally_import_to_staging
 
 # Scrape all bills.
 pupa update lametro --scrape bills window=0
 SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
-import_to_staging
+conditionally_import_to_staging

--- a/dags/scripts/full-scrape.sh
+++ b/dags/scripts/full-scrape.sh
@@ -21,5 +21,5 @@ import_to_staging
 
 # Scrape all bills.
 pupa update lametro --scrape bills window=0
-DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
+SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
 import_to_staging

--- a/dags/scripts/full-scrape.sh
+++ b/dags/scripts/full-scrape.sh
@@ -1,11 +1,25 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+import_to_staging() {
+    # If the database URL does not contain "staging", it's the production
+    # database. Append "_staging" and import. Assumes that the staging and
+    # production databases live on the same server, and follow the naming
+    # convention "${DATABASE_NAME}" and "${DATABASE_NAME}_staging".
+    if [[ "$DATABASE_URL" != *"staging"* ]]; then
+        STAGING_DATABASE_URL="${LA_METRO_DATABASE_URL}_staging"
+        echo "Importing into staging database ${STAGING_DATABASE_URL}"
+        SHARED_DB=True DATABASE_URL=$STAGING_DATABASE_URL pupa update lametro --import || echo "${STAGING_DATABASE_URL} does not exist"
+    fi
+}
 
 # Bills are windowed to 3 days by default. Scrape all people, all events, and
 # windowed bills.
 pupa update lametro --scrape
-DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
+SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
+import_to_staging
 
 # Scrape all bills.
 pupa update lametro --scrape bills window=0
 DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
+import_to_staging

--- a/dags/scripts/targeted-scrape.sh
+++ b/dags/scripts/targeted-scrape.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 pupa update --datadir=/cache/$TARGET/_data/ lametro --scrape $TARGET window=$WINDOW --rpm=$RPM

--- a/dags/scripts/targeted-scrape.sh
+++ b/dags/scripts/targeted-scrape.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -e
 
-pupa update --datadir=/cache/$TARGET/_data/ lametro --scrape $TARGET window=$WINDOW --rpm=$RPM
-DATABASE_URL=$LA_METRO_DATABASE_URL pupa update --datadir=/cache/$TARGET/_data/ lametro --import
+SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update --datadir=/cache/$TARGET/_data/ lametro $TARGET window=$WINDOW --rpm=$RPM


### PR DESCRIPTION
## Description

This PR extends the full scrape to populate the staging database, closes #23.

It also converts both scripts to bash, and combines the targeted scrape scrape / import command into a single pupa command, since we're only doing one import.

## Testing instructions

- Replace [this line](https://github.com/datamade/la-metro-dashboard/blob/a37838531d016bbfb7af5bc36b43df62447e2a04/dags/scripts/full-scrape.sh#L18) to read `pupa update lametro --scrape bills --rpm=0 window=0.05`, then comment out [these lines](https://github.com/datamade/la-metro-dashboard/blob/a37838531d016bbfb7af5bc36b43df62447e2a04/dags/scripts/full-scrape.sh#L23=L25).
- Run the app and dashboard, as described in the README.
- Turn on `daily_scraping` and, if a run does not start automatically, trigger a run. Follow the logs and confirm that the command runs as expected (some bills are scraped and imported).
- Undo your changes.
- Turn on `windowed_bill_scraping` and, if a run does not start automatically, trigger a run. Follow the logs and confirm that the command runs as expected (some bills are scraped and imported).
