### PR TITLE
Run support scrape schedule during test data entry

### DIFF
--- a/dags/friday_hourly_scraping.py
+++ b/dags/friday_hourly_scraping.py
@@ -39,7 +39,7 @@ def friday_hourly_scraping():
 with DAG(
     'friday_hourly_scraping',
     default_args=default_args,
-    schedule_interval='0,5 17-19 * * 1',
+    schedule_interval='0,5 18-21 * * 1',
     description=DAG_DESCRIPTIONS['friday_hourly_scraping']
 ) as dag:
 

--- a/dags/friday_hourly_scraping.py
+++ b/dags/friday_hourly_scraping.py
@@ -39,7 +39,7 @@ def friday_hourly_scraping():
 with DAG(
     'friday_hourly_scraping',
     default_args=default_args,
-    schedule_interval='0,5 21-23 * * 5',
+    schedule_interval='0,5 17-19 * * 1',
     description=DAG_DESCRIPTIONS['friday_hourly_scraping']
 ) as dag:
 

--- a/dags/windowed_bill_scraping.py
+++ b/dags/windowed_bill_scraping.py
@@ -37,7 +37,7 @@ def handle_scheduling():
     # 9pm FRIDAY through 5am SATURDAY, only run at 35,50 minutes
     now = datetime.now()
 
-    if now.weekday == 1 and now.hour >= 17:
+    if now.weekday == 1 and now.hour >= 18:
         if now.minute < 35:
             return 'no_scrape'
         return 'larger_windowed_bill_scrape'

--- a/dags/windowed_bill_scraping.py
+++ b/dags/windowed_bill_scraping.py
@@ -37,7 +37,7 @@ def handle_scheduling():
     # 9pm FRIDAY through 5am SATURDAY, only run at 35,50 minutes
     now = datetime.now()
 
-    if now.weekday == 5 and now.hour >= 9:
+    if now.weekday == 1 and now.hour >= 17:
         if now.minute < 35:
             return 'no_scrape'
         return 'larger_windowed_bill_scrape'

--- a/dags/windowed_event_scraping.py
+++ b/dags/windowed_event_scraping.py
@@ -37,7 +37,7 @@ def handle_scheduling():
     # 9pm FRIDAY through 5am SATURDAY, only run at 30,45 minutes
     now = datetime.now()
 
-    if now.weekday == 1 and now.hour >= 17:
+    if now.weekday == 1 and now.hour >= 18:
         if now.minute < 30:
             return 'no_scrape'
         return 'larger_windowed_event_scrape'

--- a/dags/windowed_event_scraping.py
+++ b/dags/windowed_event_scraping.py
@@ -37,7 +37,7 @@ def handle_scheduling():
     # 9pm FRIDAY through 5am SATURDAY, only run at 30,45 minutes
     now = datetime.now()
 
-    if now.weekday == 5 and now.hour >= 9:
+    if now.weekday == 1 and now.hour >= 17:
         if now.minute < 30:
             return 'no_scrape'
         return 'larger_windowed_event_scrape'


### PR DESCRIPTION
### Description

This PR updates the bill and event scraping, plus the Friday hourly scraping, DAGs to run fast, full scrapes at the top of the hour, and broader scrapes twice an hour, during scheduled test data entry at 14:00 Central /  19:00 UTC. 

We can close this and revert the manual deployment after test data entry has concluded.