### PR TITLE
Patch bug in support window scheduling

### DIFF
--- a/dags/constants.py
+++ b/dags/constants.py
@@ -37,3 +37,23 @@ DAG_DESCRIPTIONS = {
     'hourly_processing': 'Refresh the document cache, compile bill and event packets, extract attachment text, update the search index, and confirm the search index and database contain the same number of bills at 10, 25, 40, and 55 minutes past the hour.',
     'refresh_guid': 'Sync Metro subjects with SmartLogic terms once nightly.',
 }
+
+def IN_SUPPORT_WINDOW():
+    '''
+    Support window:
+
+    UTC: 9:00 pm Friday to 5:50 am Saturday
+    CST: 3:00 pm Friday to 11:50 pm Friday
+    CDT: 4:00 pm Friday to 12:50 am Saturday
+    '''
+    now = datetime.now()
+
+    # Monday is 0, Sunday is 6:
+    # https://docs.python.org/3.7/library/datetime.html#datetime.date.weekday
+    FRIDAY = 4
+    SATURDAY = 5
+
+    friday_night = now.weekday() == FRIDAY and now.hour >= 21
+    saturday_morning = now.weekday() == SATURDAY and now.hour <= 5
+
+    return friday_night or saturday_morning

--- a/dags/fast_full_scraping.py
+++ b/dags/fast_full_scraping.py
@@ -6,7 +6,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
 
 from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
-    DAG_DESCRIPTIONS, START_DATE
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -32,15 +32,13 @@ docker_base_environment = {
 }
 
 def fast_full_scraping():
-    now = datetime.now()
+    if IN_SUPPORT_WINDOW():
+        now = datetime.now()
 
-    friday_night = now.weekday == 5 and now.hour >= 21
-    saturday_morning = now.weekday == 6 and now.hour <= 5
-
-    if friday_night or saturday_morning:
-        if datetime.now().minute < 5:
+        if now.minute < 5:
             return 'fast_full_event_scrape'
-        elif datetime.now().minute >= 5:
+
+        elif now.minute >= 5:
             return 'fast_full_bill_scrape'
 
     else:

--- a/dags/windowed_bill_scraping.py
+++ b/dags/windowed_bill_scraping.py
@@ -6,7 +6,7 @@ from airflow.operators.python_operator import BranchPythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
 from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
-    DAG_DESCRIPTIONS, START_DATE
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -33,18 +33,14 @@ docker_base_environment = {
 }
 
 def handle_scheduling():
-    # SUNDAY THROUGH SATURDAY
-    # 9pm FRIDAY through 5am SATURDAY, only run at 35,50 minutes
-    now = datetime.now()
-
-    friday_night = now.weekday == 5 and now.hour >= 21
-    saturday_morning = now.weekday == 6 and now.hour <= 5
-
     # If it's between 9 p.m. UTC on Friday and 6 a.m. UTC on Saturday
-    if friday_night or saturday_morning:
-        # Skip the windowed scrape (fast full scrape will run)
+    if IN_SUPPORT_WINDOW():
+        now = datetime.now()
+
         if now.minute < 35:
+            # Skip the windowed scrape (fast full scrape will run)
             return 'no_scrape'
+
         return 'larger_windowed_bill_scrape'
 
     return 'windowed_bill_scrape'

--- a/dags/windowed_event_scraping.py
+++ b/dags/windowed_event_scraping.py
@@ -6,7 +6,7 @@ from airflow.operators.python_operator import BranchPythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
 from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
-    DAG_DESCRIPTIONS, START_DATE
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -33,18 +33,14 @@ docker_base_environment = {
 }
 
 def handle_scheduling():
-    # SUNDAY THROUGH SATURDAY
-    # 9pm FRIDAY through 5am SATURDAY, only run at 30,45 minutes
-    now = datetime.now()
-
-    friday_night = now.weekday == 5 and now.hour >= 21
-    saturday_morning = now.weekday == 6 and now.hour <= 5
-
     # If it's between 9 p.m. UTC on Friday and 6 a.m. UTC on Saturday
-    if friday_night or saturday_morning:
-        # Skip the windowed scrape (fast full scrape will run)
+    if IN_SUPPORT_WINDOW():
+        now = datetime.now()
+
         if now.minute < 30:
+            # Skip the windowed scrape (fast full scrape will run)
             return 'no_scrape'
+
         return 'larger_windowed_event_scrape'
 
     return 'windowed_event_scrape'


### PR DESCRIPTION
## Description

This PR:

- Patches a bug in support window scheduling (`datetime.now().weekday` is actually a method)
- Pulls out support window scheduling into a reusable method

Handles #52.

## Testing instructions

- Run the app locally as described in the README
- Turn on the `fast_full_scraping`, `windowed_event_scraping`, and `windowed_bill_scraping` DAGs and confirm they run as expected given the current time, i.e., fast full scrape does not run outside of support window, regular windowed scrapes run outside of support window.