### PR TITLE
SPIKE: Lift bill scrape scheduling entirely into cron

### DIFF
--- a/dags/fast_full_bill_scraping_friday.py
+++ b/dags/fast_full_bill_scraping_friday.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import BranchPythonOperator
+
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
+from operators.blackbox_docker_operator import BlackboxDockerOperator
+
+
+default_args = {
+    'start_date': START_DATE,
+    'execution_timeout': timedelta(hours=1),
+}
+
+docker_default_args = {
+    'image': 'datamade/scrapers-us-municipal',
+    'volumes': [
+        '{}:/app/scraper_scripts'.format(os.path.join(AIRFLOW_DIR_PATH, 'dags', 'scripts'))
+    ],
+}
+
+docker_environment = {
+    'DECRYPTED_SETTINGS': 'pupa_settings.py',
+    'DESTINATION_SETTINGS': 'pupa_settings.py',
+    'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
+    'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'TARGET': 'bills',
+    'WINDOW': 0,
+    'RPM': 0,
+}
+
+with DAG(
+    'fast_full_scraping',
+    default_args=default_args,
+    schedule_interval='5 21-23 * * 5',
+    description=DAG_DESCRIPTIONS['fast_full_scraping']
+) as dag:
+
+    bill_scrape = BlackboxDockerOperator(
+        task_id='fast_full_bill_scrape',
+        command='scraper_scripts/targeted-scrape.sh',
+        environment=docker_environment,
+        **docker_default_args
+    )

--- a/dags/fast_full_bill_scraping_friday.py
+++ b/dags/fast_full_bill_scraping_friday.py
@@ -33,7 +33,7 @@ docker_environment = {
 }
 
 with DAG(
-    'fast_full_scraping',
+    'fast_full_bill_scraping_friday',
     default_args=default_args,
     schedule_interval='5 21-23 * * 5',
     description=DAG_DESCRIPTIONS['fast_full_scraping']

--- a/dags/fast_full_bill_scraping_saturday.py
+++ b/dags/fast_full_bill_scraping_saturday.py
@@ -33,7 +33,7 @@ docker_environment = {
 }
 
 with DAG(
-    'fast_full_scraping',
+    'fast_full_bill_scraping_saturday',
     default_args=default_args,
     schedule_interval='5 0-5 * * 6',
     description=DAG_DESCRIPTIONS['fast_full_scraping']

--- a/dags/fast_full_bill_scraping_saturday.py
+++ b/dags/fast_full_bill_scraping_saturday.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import BranchPythonOperator
+
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
+from operators.blackbox_docker_operator import BlackboxDockerOperator
+
+
+default_args = {
+    'start_date': START_DATE,
+    'execution_timeout': timedelta(hours=1),
+}
+
+docker_default_args = {
+    'image': 'datamade/scrapers-us-municipal',
+    'volumes': [
+        '{}:/app/scraper_scripts'.format(os.path.join(AIRFLOW_DIR_PATH, 'dags', 'scripts'))
+    ],
+}
+
+docker_environment = {
+    'DECRYPTED_SETTINGS': 'pupa_settings.py',
+    'DESTINATION_SETTINGS': 'pupa_settings.py',
+    'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
+    'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'TARGET': 'bills',
+    'WINDOW': 0,
+    'RPM': 0,
+}
+
+with DAG(
+    'fast_full_scraping',
+    default_args=default_args,
+    schedule_interval='5 0-5 * * 6',
+    description=DAG_DESCRIPTIONS['fast_full_scraping']
+) as dag:
+
+    bill_scrape = BlackboxDockerOperator(
+        task_id='fast_full_bill_scrape',
+        command='scraper_scripts/targeted-scrape.sh',
+        environment=docker_environment,
+        **docker_default_args
+    )

--- a/dags/windowed_bill_scraping_friday.py
+++ b/dags/windowed_bill_scraping_friday.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python_operator import BranchPythonOperator
+from airflow.operators.dummy_operator import DummyOperator
+
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE
+from operators.blackbox_docker_operator import BlackboxDockerOperator
+
+
+default_args = {
+    'start_date': START_DATE,
+    'execution_timeout': timedelta(hours=3)
+}
+
+docker_default_args = {
+    'image': 'datamade/scrapers-us-municipal',
+    'volumes': [
+        '{}:/app/scraper_scripts'.format(os.path.join(AIRFLOW_DIR_PATH, 'dags', 'scripts'))
+    ],
+    'command': 'scraper_scripts/targeted-scrape.sh',
+}
+
+docker_environment = {
+    'DECRYPTED_SETTINGS': 'pupa_settings.py',
+    'DESTINATION_SETTINGS': 'pupa_settings.py',
+    'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
+    'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'TARGET': 'bills',
+    'WINDOW': 1,
+    'RPM': 60,
+}
+
+with DAG(
+    'windowed_bill_scraping_friday',
+    default_args=default_args,
+    schedule_interval='35,50 21-23 * * 5',
+    description=DAG_DESCRIPTIONS['windowed_bill_scraping']
+) as dag:
+
+    large_windowed_bill_scrape = BlackboxDockerOperator(
+        task_id='large_windowed_bill_scrape',
+        environment=docker_environment,
+        **docker_default_args
+    )

--- a/dags/windowed_bill_scraping_saturday.py
+++ b/dags/windowed_bill_scraping_saturday.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python_operator import BranchPythonOperator
+from airflow.operators.dummy_operator import DummyOperator
+
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
+from operators.blackbox_docker_operator import BlackboxDockerOperator
+
+
+default_args = {
+    'start_date': START_DATE,
+    'execution_timeout': timedelta(hours=3)
+}
+
+docker_default_args = {
+    'image': 'datamade/scrapers-us-municipal',
+    'volumes': [
+        '{}:/app/scraper_scripts'.format(os.path.join(AIRFLOW_DIR_PATH, 'dags', 'scripts'))
+    ],
+    'command': 'scraper_scripts/targeted-scrape.sh',
+}
+
+docker_environment = {
+    'DECRYPTED_SETTINGS': 'pupa_settings.py',
+    'DESTINATION_SETTINGS': 'pupa_settings.py',
+    'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
+    'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'TARGET': 'bills',
+    'WINDOW': 1,
+    'RPM': 60,
+}
+
+with DAG(
+    'windowed_bill_scraping_saturday',
+    default_args=default_args,
+    schedule_interval='35,50 0-5 * * 6',
+    description=DAG_DESCRIPTIONS['windowed_bill_scraping']
+) as dag:
+
+    large_windowed_bill_scrape = BlackboxDockerOperator(
+        task_id='large_windowed_bill_scrape',
+        environment=docker_environment,
+        **docker_default_args
+    )

--- a/dags/windowed_bill_scraping_saturday_am.py
+++ b/dags/windowed_bill_scraping_saturday_am.py
@@ -34,7 +34,7 @@ docker_environment = {
 }
 
 with DAG(
-    'windowed_bill_scraping_saturday',
+    'windowed_bill_scraping_saturday_am',
     default_args=default_args,
     schedule_interval='35,50 0-5 * * 6',
     description=DAG_DESCRIPTIONS['windowed_bill_scraping']

--- a/dags/windowed_bill_scraping_saturday_pm.py
+++ b/dags/windowed_bill_scraping_saturday_pm.py
@@ -29,14 +29,14 @@ docker_environment = {
     'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
     'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
     'TARGET': 'bills',
-    'WINDOW': 0.05,
+    'WINDOW': 1,
     'RPM': 60,
 }
 
 with DAG(
-    'windowed_bill_scraping_sunday_thru_thursday',
+    'windowed_bill_scraping_saturday_pm',
     default_args=default_args,
-    schedule_interval='5,20,35,50 * * * 0-4',
+    schedule_interval='5,20,35,50 6-23 * * 6',
     description=DAG_DESCRIPTIONS['windowed_bill_scraping']
 ) as dag:
 

--- a/dags/windowed_bill_scraping_sunday_thru_thursday.py
+++ b/dags/windowed_bill_scraping_sunday_thru_thursday.py
@@ -34,7 +34,7 @@ docker_environment = {
 }
 
 with DAG(
-    'windowed_bill_scraping',
+    'windowed_bill_scraping_sunday_thru_thursday',
     default_args=default_args,
     schedule_interval='5,20,35,50 0-20 * * 5',
     description=DAG_DESCRIPTIONS['windowed_bill_scraping']

--- a/dags/windowed_bill_scraping_sunday_thru_thursday.py
+++ b/dags/windowed_bill_scraping_sunday_thru_thursday.py
@@ -23,60 +23,25 @@ docker_default_args = {
     'command': 'scraper_scripts/targeted-scrape.sh',
 }
 
-docker_base_environment = {
+docker_environment = {
     'DECRYPTED_SETTINGS': 'pupa_settings.py',
     'DESTINATION_SETTINGS': 'pupa_settings.py',
     'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
     'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
     'TARGET': 'bills',
+    'WINDOW': 0.05,
     'RPM': 60,
 }
-
-def handle_scheduling():
-    # If it's between 9 p.m. UTC on Friday and 6 a.m. UTC on Saturday
-    if IN_SUPPORT_WINDOW():
-        now = datetime.now()
-
-        if now.minute < 35:
-            # Skip the windowed scrape (fast full scrape will run)
-            return 'no_scrape'
-
-        return 'larger_windowed_bill_scrape'
-
-    return 'windowed_bill_scrape'
 
 with DAG(
     'windowed_bill_scraping',
     default_args=default_args,
-    schedule_interval='5,20,35,50 * * * 0-6',
+    schedule_interval='5,20,35,50 0-20 * * 5',
     description=DAG_DESCRIPTIONS['windowed_bill_scraping']
 ) as dag:
 
-    branch = BranchPythonOperator(
-        task_id='handle_scheduling',
-        python_callable=handle_scheduling
-    )
-
-    windowed_bill_scrape_environment = docker_base_environment.copy()
-    windowed_bill_scrape_environment['WINDOW'] = 0.05
-
     windowed_bill_scrape = BlackboxDockerOperator(
         task_id='windowed_bill_scrape',
-        environment=windowed_bill_scrape_environment,
+        environment=docker_environment,
         **docker_default_args
     )
-
-    larger_windowed_bill_scrape_environment = docker_base_environment.copy()
-    larger_windowed_bill_scrape_environment['WINDOW'] = 1
-
-    larger_windowed_bill_scrape = BlackboxDockerOperator(
-        task_id='larger_windowed_bill_scrape',
-        environment=larger_windowed_bill_scrape_environment,
-        **docker_default_args
-    )
-
-    no_scrape = DummyOperator(
-        task_id='no_scrape'
-    )
-
-branch >> [windowed_bill_scrape, larger_windowed_bill_scrape, no_scrape]


### PR DESCRIPTION
## Description

This spike implements the pattern suggested in #59 for bill scrapes.

Barring the ability to specify multiple schedules for a single task, we need to create a separate DAG for each schedule interval (Sunday through Thursday, Friday morning, and Saturday afternooon for regular windowed scrapes; Friday evening and Saturday morning for fast full scrapes and broader windowed scrapes).

The benefit of this approach is that it consolidates all scheduling in the cron layer. It also allows us to manually trigger each type of DAG from the dashboard.

The downside is that increases the number of bill scraping DAGs from two to seven, and it leads to a lot of duplicate code (though there are certainly some places we could factor out repeat configs, etc.) 