### PR TITLE
SPIKE: Consolidated bill scrape DAG with custom branch operator

### DIFF
--- a/dags/bill_scraping.py
+++ b/dags/bill_scraping.py
@@ -1,0 +1,78 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+
+from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
+    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
+from operators.blackbox_docker_operator import BlackboxDockerOperator
+from operators.scheduling_branch_operator import SchedulingBranchOperator
+
+
+default_args = {
+    'start_date': START_DATE,
+    'execution_timeout': timedelta(hours=3)
+}
+
+docker_default_args = {
+    'image': 'datamade/scrapers-us-municipal',
+    'volumes': [
+        '{}:/app/scraper_scripts'.format(os.path.join(AIRFLOW_DIR_PATH, 'dags', 'scripts'))
+    ],
+    'command': 'scraper_scripts/targeted-scrape.sh',
+}
+
+docker_base_environment = {
+    'DECRYPTED_SETTINGS': 'pupa_settings.py',
+    'DESTINATION_SETTINGS': 'pupa_settings.py',
+    'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
+    'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'TARGET': 'bills',
+    'RPM': 60,
+}
+
+with DAG(
+    'bill_scraping',
+    default_args=default_args,
+    schedule_interval='5,20,35,50 * * * *',
+    description=DAG_DESCRIPTIONS['windowed_bill_scraping'],
+) as dag:
+
+    schedule_bill_scrape = SchedulingBranchOperator(
+        task_id='schedule_bill_scrape'
+    )
+
+    regular_scrape_environment = docker_base_environment.copy()
+    regular_scrape_environment['WINDOW'] = 0.05
+
+    regular_scrape = BlackboxDockerOperator(
+        task_id='regular_scrape',
+        environment=regular_scrape_environment,
+        **docker_default_args
+    )
+
+    broader_scrape_environment = docker_base_environment.copy()
+    broader_scrape_environment['WINDOW'] = 1
+
+    broader_scrape = BlackboxDockerOperator(
+        task_id='broader_scrape',
+        environment=broader_scrape_environment,
+        **docker_default_args
+    )
+
+    fast_full_scrape_environment = docker_base_environment.copy()
+    fast_full_scrape_environment['WINDOW'] = 0
+    fast_full_scrape_environment['RPM'] = 0
+
+    fast_full_scrape = BlackboxDockerOperator(
+        task_id='fast_full_scrape',
+        environment=fast_full_scrape_environment,
+        **docker_default_args
+    )
+
+    no_scrape = DummyOperator(
+        task_id='no_scrape'
+    )
+
+schedule_bill_scrape >> [regular_scrape, broader_scrape, fast_full_scrape, no_scrape]

--- a/dags/bill_scraping.py
+++ b/dags/bill_scraping.py
@@ -5,7 +5,7 @@ from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 
 from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, \
-    DAG_DESCRIPTIONS, START_DATE, IN_SUPPORT_WINDOW
+    DAG_DESCRIPTIONS, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 from operators.scheduling_branch_operator import SchedulingBranchOperator
 

--- a/operators/scheduling_branch_operator.py
+++ b/operators/scheduling_branch_operator.py
@@ -1,0 +1,44 @@
+from airflow.operators.branch_operator import BaseBranchOperator
+from croniter import croniter
+
+
+class SchedulingBranchOperator(BaseBranchOperator):
+    def _in_support_window(self, timestamp):
+        '''
+        Support window:
+
+        UTC: 9:00 pm Friday to 5:50 am Saturday
+        CST: 3:00 pm Friday to 11:50 pm Friday
+        CDT: 4:00 pm Friday to 12:50 am Saturday
+        '''
+        # Monday is 0, Sunday is 6:
+        # https://docs.python.org/3.7/library/datetime.html#datetime.date.weekday
+        FRIDAY = 4
+        SATURDAY = 5
+
+        friday_night = timestamp.weekday() == FRIDAY and timestamp.hour >= 21
+        saturday_morning = timestamp.weekday() == SATURDAY and timestamp.hour <= 5
+
+        return friday_night or saturday_morning
+
+    def _index_in_interval(self, interval, timestamp):
+        minutes, *_ = croniter(interval).expanded
+        return minutes.split(',').index(timestamp.minute)
+
+    def choose_branch(self, context):
+        interval = context['dag'].schedule_interval
+        timestamp = context['execution_date']
+
+        if self._in_support_window(timestamp):
+            index_in_interval = self._index_in_interval(interval, timestamp)
+
+            if index_in_interval == 0:
+                return 'fast_full_scrape'
+
+            elif index_in_interval == 1:
+                return 'no_scrape'
+
+            elif index_in_interval in (2, 3):
+                return 'broader_scrape'
+
+        return 'regular_scrape'


### PR DESCRIPTION
## Description

This PR spikes an approach that full separates DAG and task scheduling. It achieves this separation by defining the minute intervals at which a particular scraping DAG should run via cron, then defining a custom scheduling branch operator to determine what kind of task the DAG should run, based on execution date.

This is inspired by the example of the custom branch operator offered in the Airflow documentation: https://airflow.apache.org/docs/stable/concepts.html#branching

The benefit of this approach is that allows us to consolidate all variations of scraping task for an entity into a single DAG. (In fact, one could imagine extending this to capture the nightly scrapes, as well.) This reduces the overall number of DAGs we have to maintain.

The downside is that it means scheduling happens in two places. The scheduling branch operator is less obvious than explicit cron definitions. It does not allow us to trigger a particular kind of scrape at will, either.