### PR TITLE
Double daily scrape timeout, remove duplicate bill scrape

### DIFF
--- a/dags/daily_scraping.py
+++ b/dags/daily_scraping.py
@@ -10,7 +10,7 @@ from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 default_args = {
     'start_date': START_DATE,
-    'execution_timeout': timedelta(hours=12),
+    'execution_timeout': timedelta(hours=24),
     'image': 'datamade/scrapers-us-municipal',
     'environment': {
         'DECRYPTED_SETTINGS': 'pupa_settings.py',

--- a/dags/scripts/full-scrape.sh
+++ b/dags/scripts/full-scrape.sh
@@ -8,9 +8,8 @@ conditionally_import_to_staging() {
     fi
 }
 
-# Bills are windowed to 3 days by default. Scrape all people, all events, and
-# windowed bills.
-pupa update lametro --scrape
+# Bills are windowed to 3 days by default. Scrape all people and all events.
+pupa update lametro --scrape people events
 SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
 conditionally_import_to_staging
 


### PR DESCRIPTION
## Description

This pull request increases the timeout on the daily scrape and removes duplicate bill scraping by specifying to scrape people and events, which are not windowed by default, then scrape bills with a window of zero. (Running a bare `pupa update` also scrapes bills with a window of 3.)

Assuming this scrape runs, we should consult the log timestamps to see how long it actually takes and revise the window down.

Related to #64