### PR TITLE
Revert overnight scrape to 12-hour timeout, add stopgap DAG for person sync

### DIFF
--- a/dags/person_scraping.py
+++ b/dags/person_scraping.py
@@ -4,7 +4,7 @@ import os
 from airflow import DAG
 
 from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_STAGING_DATABASE_URL, \
-    AIRFLOW_DIR_PATH, DAG_DESCRIPTIONS, START_DATE
+    AIRFLOW_DIR_PATH, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -25,13 +25,13 @@ default_args = {
 }
 
 with DAG(
-    'daily_scraping',
+    'person_scraping',
     default_args=default_args,
-    schedule_interval='5 3 * * 0-5',
-    description=DAG_DESCRIPTIONS['daily_scraping']
+    schedule_interval='5 3 * * *',
+    description='Scrape people and organizations once per day'
 ) as dag:
 
     t1 = BlackboxDockerOperator(
-        task_id='daily_scraping',
-        command='scraper_scripts/full-scrape.sh'
+        task_id='person_scraping',
+        command='scraper_scripts/person-scrape.sh'
     )

--- a/dags/scripts/person-scrape.sh
+++ b/dags/scripts/person-scrape.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+conditionally_import_to_staging() {
+    if [[ -n "$LA_METRO_STAGING_DATABASE_URL" ]]; then
+        echo "Importing into staging database ${LA_METRO_STAGING_DATABASE_URL}"
+        SHARED_DB=True DATABASE_URL=$LA_METRO_STAGING_DATABASE_URL pupa update lametro --import || echo "${LA_METRO_STAGING_DATABASE_URL} does not exist"
+    fi
+}
+
+# Scrape people
+pupa update lametro --scrape people
+SHARED_DB=True DATABASE_URL=$LA_METRO_DATABASE_URL pupa update lametro --import
+conditionally_import_to_staging


### PR DESCRIPTION
### Description

See title. These changes represent a stopgap measure, until we have bandwidth to investigate a deeper fix for overnight scrapes.