### PR TITLE
Repair conditional imports to staging

### DIFF
--- a/dags/full_scrape.py
+++ b/dags/full_scrape.py
@@ -5,7 +5,8 @@ from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, START_DATE
+from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_STAGING_DATABASE_URL, \
+    AIRFLOW_DIR_PATH, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -27,6 +28,7 @@ docker_base_environment = {
     'DESTINATION_SETTINGS': 'pupa_settings.py',
     'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
     'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'LA_METRO_STAGING_DATABASE_URL': LA_METRO_STAGING_DATABASE_URL,
     'RPM': 60,
 }
 

--- a/dags/scrape_factory.py
+++ b/dags/scrape_factory.py
@@ -4,7 +4,8 @@ from airflow import DAG
 from croniter import croniter
 
 from dags.config import SCRAPING_DAGS
-from dags.constants import LA_METRO_DATABASE_URL, AIRFLOW_DIR_PATH, START_DATE
+from dags.constants import LA_METRO_DATABASE_URL, LA_METRO_STAGING_DATABASE_URL, \
+    AIRFLOW_DIR_PATH, START_DATE
 from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 
@@ -13,6 +14,7 @@ docker_base_environment = {
     'DESTINATION_SETTINGS': 'pupa_settings.py',
     'DATABASE_URL': LA_METRO_DATABASE_URL,  # For use by entrypoint
     'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,  # For use in scraping scripts
+    'LA_METRO_STAGING_DATABASE_URL': LA_METRO_STAGING_DATABASE_URL,
 }
 
 def get_dag_id(dag_name, dag_config, interval):

--- a/dags/scripts/targeted-scrape.sh
+++ b/dags/scripts/targeted-scrape.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
+#
+# Scrape and import data to the production database and, if a connection string
+# is defined, the staging database.
+#
+# N.b., we append a definition for DATABASE_URL to pupa_settings.py that sources
+# the value from the LA_METRO_DATABASE_URL environment variable. This variable
+# is set to the production database URI in the Supervisor config, i.e., we do
+# not need to pass a value for the production scrape and import. We set it
+# equal to the staging database connection string for the staging import.
+
 set -e
 
 conditionally_import_to_staging() {
     if [[ -n "$LA_METRO_STAGING_DATABASE_URL" ]]; then
-        echo "Importing into staging database ${LA_METRO_STAGING_DATABASE_URL}"
-        SHARED_DB=True LA_METRO_DATABASE_URL=$LA_METRO_STAGING_DATABASE_URL pupa update lametro --import || echo "${LA_METRO_STAGING_DATABASE_URL} does not exist"
+        SHARED_DB=True LA_METRO_DATABASE_URL=$LA_METRO_STAGING_DATABASE_URL \
+            pupa update --datadir=/cache/$TARGET/_data/ lametro --import $TARGET \
+            || echo "${LA_METRO_STAGING_DATABASE_URL} does not exist"
+
+        echo "Imported into staging database ${LA_METRO_STAGING_DATABASE_URL}"
     else
         echo 'No value set for $LA_METRO_STAGING_DATABASE_URL'
     fi
@@ -19,5 +32,7 @@ else
         pupa update --datadir=/cache/$TARGET/_data/ lametro $TARGET \
         --rpm=$RPM
 fi
+
+echo "Scraped and imported into production database ${LA_METRO_DATABASE_URL}"
 
 conditionally_import_to_staging


### PR DESCRIPTION
## Overview

This PR adds `LA_METRO_STAGING_DATBASE` to scrape container environments and updates the targeted scrape script to include a note on relevant environment variables and point the production and staging imports at the same data directory. 

It is a continuation of the work to address #58. The full diff for these changes is here: https://github.com/datamade/la-metro-dashboard/compare/8c3d38e906862d4d62781b34ef556d6f2ee7e52f..3c30e74e2f401f836013e936d0a648f5df59f341

Apologies for some commits directly to master.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

I tested this locally using a windowed event scrape.

Log output when staging database value is set (I just used the "production" URL for simplicity's sake):

```
[2020-12-18 15:39:26,217] {docker.py:258} INFO - import jurisdictions...
[2020-12-18 15:39:26,251] {docker.py:258} INFO - import organizations...
[2020-12-18 15:39:26,302] {docker.py:258} INFO - import people...
[2020-12-18 15:39:26,304] {docker.py:258} INFO - import posts...
[2020-12-18 15:39:26,399] {docker.py:258} INFO - import memberships...
[2020-12-18 15:39:26,402] {docker.py:258} INFO - import bills...
[2020-12-18 15:39:26,413] {docker.py:258} INFO - import events...
[2020-12-18 15:39:26,846] {docker.py:258} INFO - 12/18/2020 09:39:26 ERROR pupa: cannot resolve pseudo id to Organization: ~{"name": "Measure R Independent Taxpayer Oversight Committee\u200b - Public Hearing"}
[2020-12-18 15:39:27,196] {docker.py:258} INFO - import vote events...
[2020-12-18 15:39:27,233] {docker.py:258} INFO - lametro (scrape, import)
[2020-12-18 15:39:27,235] {docker.py:258} INFO - events: {'window': '0.05'}
events scrape:
  duration:  0:00:45.786559
  objects:
    event: 21
[2020-12-18 15:39:27,236] {docker.py:258} INFO - jurisdiction scrape:
[2020-12-18 15:39:27,237] {docker.py:258} INFO - duration:  0:00:00.170933
  objects:
    jurisdiction: 1
[2020-12-18 15:39:27,238] {docker.py:258} INFO - organization: 3
    post: 18
import:
  event: 0 new 0 updated 21 noop
[2020-12-18 15:39:27,240] {docker.py:258} INFO - jurisdiction: 0 new 0 updated 1 noop
  organization: 0 new 0 updated 3 noop
  post: 0 new 0 updated 18 noop
[2020-12-18 15:39:27,642] {docker.py:258} INFO - Scraped and imported into production database postgres://postgres:postgres@postgres:5432/lametro
[2020-12-18 15:39:30,093] {docker.py:258} INFO - lametro (import)
  events: {}
[2020-12-18 15:39:30,133] {docker.py:258} INFO - import jurisdictions...
[2020-12-18 15:39:30,184] {docker.py:258} INFO - import organizations...
[2020-12-18 15:39:30,221] {docker.py:258} INFO - import people...
[2020-12-18 15:39:30,226] {docker.py:258} INFO - import posts...
[2020-12-18 15:39:30,357] {docker.py:258} INFO - import memberships...
[2020-12-18 15:39:30,361] {docker.py:258} INFO - import bills...
[2020-12-18 15:39:30,373] {docker.py:258} INFO - import events...
[2020-12-18 15:39:30,591] {docker.py:258} INFO - 12/18/2020 09:39:30 ERROR pupa: cannot resolve pseudo id to Organization: ~{"name": "Measure R Independent Taxpayer Oversight Committee\u200b - Public Hearing"}
[2020-12-18 15:39:31,093] {docker.py:258} INFO - import vote events...
[2020-12-18 15:39:31,115] {docker.py:258} INFO - lametro (import)
  events: {}
import:
[2020-12-18 15:39:31,120] {docker.py:258} INFO - event: 0 new 0 updated 21 noop
[2020-12-18 15:39:31,125] {docker.py:258} INFO - jurisdiction: 0 new 0 updated 1 noop
  organization: 0 new 0 updated 3 noop
  post: 0 new 0 updated 18 noop
[2020-12-18 15:39:31,504] {docker.py:258} INFO - Imported into staging database postgres://postgres:postgres@postgres:5432/lametro
[2020-12-18 15:39:31,995] {taskinstance.py:1065} INFO - Marking task as SUCCESS.dag_id=windowed_event_scrape_fri, task_id=scrape, execution_date=20201218T153744, start_date=20201218T153753, end_date=20201218T153931
```

Log output when the staging database is an empty string:

```
[2020-12-18 15:26:08,559] {docker.py:258} INFO - import jurisdictions...
[2020-12-18 15:26:08,605] {docker.py:258} INFO - import organizations...
[2020-12-18 15:26:08,702] {docker.py:258} INFO - import people...
[2020-12-18 15:26:08,706] {docker.py:258} INFO - import posts...
[2020-12-18 15:26:08,847] {docker.py:258} INFO - import memberships...
[2020-12-18 15:26:08,849] {docker.py:258} INFO - import bills...
[2020-12-18 15:26:08,863] {docker.py:258} INFO - import events...
[2020-12-18 15:26:09,379] {docker.py:258} INFO - 12/18/2020 09:26:09 ERROR pupa: cannot resolve pseudo id to Organization: ~{"name": "Measure R Independent Taxpayer Oversight Committee\u200b - Public Hearing"}
[2020-12-18 15:26:09,444] {docker.py:258} INFO - import vote events...
[2020-12-18 15:26:09,475] {docker.py:258} INFO - lametro (scrape, import)
  events: {'window': '0.05'}
events scrape:
  duration:  0:00:45.715229
  objects:
    event: 21
jurisdiction scrape:
  duration:  0:00:00.133481
  objects:
[2020-12-18 15:26:09,477] {docker.py:258} INFO - jurisdiction: 1
[2020-12-18 15:26:09,479] {docker.py:258} INFO - organization: 3
[2020-12-18 15:26:09,482] {docker.py:258} INFO - post: 18
import:
  event: 0 new 0 updated 21 noop
[2020-12-18 15:26:09,485] {docker.py:258} INFO - jurisdiction: 0 new 0 updated 1 noop
[2020-12-18 15:26:09,486] {docker.py:258} INFO - organization: 0 new 0 updated 3 noop
  post: 0 new 0 updated 18 noop
[2020-12-18 15:26:10,095] {docker.py:258} INFO - Scraped and imported into production database postgres://postgres:postgres@postgres:5432/lametro
No value set for $LA_METRO_STAGING_DATABASE_URL
```

We should obviously monitor this on staging and then production once the relevant deployments are made.