### PR TITLE
Move full scrape back to 9 p.m. PDT / 8 p.m. PST

### DIFF
--- a/dags/full_scrape.py
+++ b/dags/full_scrape.py
@@ -35,7 +35,7 @@ docker_base_environment = {
 with DAG(
     'full_scrape',
     default_args=default_args,
-    schedule_interval='5 3 * * 0-5',
+    schedule_interval='5 4 * * 0-5',
     description=(
         'Scrape all people and committees, bills, and events "politely" – that '
         'is, with requests throttled to 60 per minute, or 1 per second. This '


### PR DESCRIPTION
## Overview

See title. Revision of https://github.com/datamade/la-metro-dashboard/pull/54.

![Screen Shot 2021-01-12 at 3 22 15 PM](https://user-images.githubusercontent.com/12176173/104376042-fb96a880-54e9-11eb-8291-228a37b77c3a.png)

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

Handles #39
