### PR TITLE
update_index removes deleted bills in hourly processing

### DIFF
--- a/dags/hourly_processing.py
+++ b/dags/hourly_processing.py
@@ -48,9 +48,9 @@ with DAG(
     )
 
     if datetime.now().minute >= 55:
-        update_index_command = 'python manage.py update_index --batch-size=100'
+        update_index_command = 'python manage.py update_index --batch-size=100 --remove'
     else:
-        update_index_command = 'python manage.py update_index --batch-size=100 --age=1'
+        update_index_command = 'python manage.py update_index --batch-size=100 --age=1 --remove'
 
     t4 = BlackboxDockerOperator(
         task_id='update_index',


### PR DESCRIPTION
## Overview

This PR addresses [la-metro-councilmatic issue #623](https://github.com/datamade/la-metro-councilmatic/issues/623), where bills that are deleted or made private are not removed from the search index.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * copy last commit for this PR and go to the CodeDeploy page for the `la-metro-dashboard-staging` app, then trigger a deployment of the staging app
 * check the `Code` tab to make sure changes are present
 * trigger the `hourly processing` DAG and make sure it runs without error

Handles [la-metro-councilmatic/issues/623](https://github.com/datamade/la-metro-councilmatic/issues/623)
