### PR TITLE
execution timeout for hourly processing from 15 to 20min

### DIFF
--- a/dags/hourly_processing.py
+++ b/dags/hourly_processing.py
@@ -10,7 +10,7 @@ from operators.blackbox_docker_operator import BlackboxDockerOperator
 
 default_args = {
     'start_date': START_DATE,
-    'execution_timeout': timedelta(minutes=15),
+    'execution_timeout': timedelta(minutes=20),
     'image': 'datamade/la-metro-councilmatic',
     'environment': {
         'LA_METRO_DATABASE_URL': LA_METRO_DATABASE_URL,


### PR DESCRIPTION
## Overview

This PR increases the execution timeout for the `hourly_processing` DAG so that the hourly processing at the beginning of the hour doesn't time out.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Wait for the DAG to run at the top of the hour and make sure it doesn't time out. Here's a link to the staging site: https://la-metro-dashboard-staging.datamade.us/tree?dag_id=hourly_processing&root=

Handles #78
