### PR TITLE
Skip scheduled scrape if previous scrape is still running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
       ca-certificates \
       curl \
       gnupg-agent \
-      software-properties-common && \
+      software-properties-common \
+      postgresql-client && \
     rm -rf /var/lib/apt/lists/* && \
     curl -fsSL https://get.docker.com -o get-docker.sh && \
     sh get-docker.sh

--- a/dags/scrape_factory.py
+++ b/dags/scrape_factory.py
@@ -1,6 +1,9 @@
 import os
 
 from airflow import DAG
+from airflow.exceptions import DagRunNotFound
+from airflow.operators.python_operator import ShortCircuitOperator
+
 from croniter import croniter
 
 from dags.config import SCRAPING_DAGS
@@ -42,6 +45,19 @@ def get_dag_id(dag_name, dag_config, interval):
     else:
         return '{0}_{1}_thru_{2}'.format(dag_name, int_day_map[days[0]], int_day_map[days[-1]])
 
+def short_circuit_if_previous_run_ongoing(**kwargs):
+    try:
+        previous_run = kwargs['dag'].get_last_dagrun(include_externally_triggered=True)
+
+    except DagRunNotFound:
+        return True
+
+    else:
+        ti = previous_run.get_task_instance('scrape')
+        current_state = ti.current_state()
+        print('Previous instance {0} in state {1}'.format(ti, current_state))
+        return current_state != 'running'
+
 seen_ids = []
 
 for dag_name, dag_config in SCRAPING_DAGS.items():
@@ -68,7 +84,13 @@ for dag_name, dag_config in SCRAPING_DAGS.items():
         docker_environment.update(dag_config['docker_environment'])
 
         with dag:
-            task = BlackboxDockerOperator(
+            check_previous = ShortCircuitOperator(
+                task_id='check_previous',
+                python_callable=short_circuit_if_previous_run_ongoing,
+                provide_context=True
+            )
+
+            scrape = BlackboxDockerOperator(
                 task_id='scrape',
                 image='ghcr.io/datamade/scrapers-us-municipal',
                 volumes=[
@@ -78,6 +100,8 @@ for dag_name, dag_config in SCRAPING_DAGS.items():
                 command=dag_config['command'],
                 environment=docker_environment
             )
+
+            check_previous >> scrape
 
         globals()[dag_id] = dag
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - LA_METRO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/lametro
       - AIRFLOW_DIR_PATH=${PWD}
       - GPG_KEYRING_PATH=${GPG_KEYRING_PATH}
-      - LA_METRO_DOCKER_IMAGE_TAG=staging
+      - LA_METRO_DOCKER_IMAGE_TAG=master
     networks:
       - app_net
     ports:
@@ -75,7 +75,7 @@ services:
       - DOCKER_NETWORK=la-metro-councilmatic_default
       - AIRFLOW_DIR_PATH=${PWD}
       - GPG_KEYRING_PATH=${GPG_KEYRING_PATH}
-      - LA_METRO_DOCKER_IMAGE_TAG=staging
+      - LA_METRO_DOCKER_IMAGE_TAG=master
     env_file:
       - .env
     networks:


### PR DESCRIPTION
## Overview

See title. This will prevent scheduled scrapes from stacking up in the event that they take longer than the 15-minute interval between runs (but complete in less time than their timeout).

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

From local testing:

![Screen Shot 2022-01-04 at 11 43 52 AM](https://user-images.githubusercontent.com/12176173/148101669-b1429b5b-fea9-42e1-89f2-ea1f8f1827bd.png)

(Pink is skipped.)

## Testing Instructions

 * Tested locally by letting the windowed bill scrape DAG run for an hour. Successfully skipped scrapes when the previous run was ongoing.
 * Once approved, will manually deploy to staging to test further.

Handles #82
