### PR TITLE
Fixed dashboard error caused by make_packet DAG

### DIFF
--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -79,7 +79,11 @@ class Dashboard(BaseView):
                 last_successful_info = self._get_last_succesful_run_date(d)
 
                 next_scheduled = d.following_schedule(datetime.now(pytz.utc))
-                next_scheduled_info = self._get_localized_time(next_scheduled)
+
+                if next_scheduled:
+                    next_scheduled_info = self._get_localized_time(next_scheduled)
+                else:
+                    next_scheduled_info = None
 
             else:
                 run_state = None

--- a/plugins/templates/dashboard.html
+++ b/plugins/templates/dashboard.html
@@ -152,8 +152,10 @@
               {% else %}
                 <td></td>
               {% endif %}
-              {% if dag.next_scheduled_date.pst_time %}
-                <td>{{ dag.next_scheduled_date.pst_time.strftime(datetime_format) }} PST<br /> {{ dag.next_scheduled_date.cst_time.strftime(datetime_format) }} CST</td>
+              {% if dag.next_scheduled_date %}
+                {% if dag.next_scheduled_date.pst_time %}
+                  <td>{{ dag.next_scheduled_date.pst_time.strftime(datetime_format) }} PST<br /> {{ dag.next_scheduled_date.cst_time.strftime(datetime_format) }} CST</td>
+                {% endif %}
               {% else %}
                 <td></td>
               {% endif %}


### PR DESCRIPTION
## Overview

This PR address the Dashboard plugin's error caused by the `make_packet` DAG having no set interval.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


## Testing Instructions

 * Make sure the `make_packet` DAG is on
 * Verify that the Dashboard view loads and `make_packet` has no scheduled 'Next Scheduled Run Date' in the 'Job Overview' table

Handles #89 
