### PR TITLE
Added authentication to metro dashboard

### DIFF
--- a/plugins/dashboard_plugin.py
+++ b/plugins/dashboard_plugin.py
@@ -9,7 +9,7 @@ from airflow.models import dag, dagrun, taskinstance
 from airflow.models.dagbag import DagBag
 from airflow.plugins_manager import AirflowPlugin
 from flask import Blueprint
-from flask_appbuilder import BaseView, expose
+from flask_appbuilder import BaseView, expose, has_access
 import pytz
 import requests
 
@@ -32,6 +32,7 @@ class Dashboard(BaseView):
         self.airflow_dag_bag = DagBag()
 
     @expose('/')
+    @has_access
     def list(self):
         dag_info = self.get_dag_info()
 


### PR DESCRIPTION
## Overview

This PR adds authentication to the LA Metro Dashboard plugin page. Users will be required to login to view it.

After this change is merged in, we will create login accounts for our colleagues at Metro.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


## Testing Instructions

 * Navigate to the dashboard and verify that the page is inaccessible if not logged in

Handles #10 
