### PR TITLE
Rename analytics DAG

### DIFF
--- a/dags/tag_analytics.py
+++ b/dags/tag_analytics.py
@@ -23,7 +23,7 @@ default_args = {
 }
 
 with DAG(
-    'analytics',
+    'tag_analytics',
     default_args=default_args,
     schedule_interval='0 0 1 * *',
     description='Generates analytics for Metro agenda tags and uploads a CSV file to Google Drive'


### PR DESCRIPTION
## Overview

This PR renames the `analytics` DAG to `tag_analytics`. In addition to being a more descriptive name, this change is meant to [update the DAG's schedule](https://github.com/datamade/la-metro-dashboard/issues/99#issuecomment-1372565035) to run only once per month.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


## Testing Instructions

 * Verify that the DAG has been renamed
 * Verify that the next scheduled run date

Handles #99 
