### PR TITLE
Remove software-properties-common package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && \
       ca-certificates \
       curl \
       gnupg-agent \
-      software-properties-common \
       postgresql-client && \
     rm -rf /var/lib/apt/lists/* && \
     curl -fsSL https://get.docker.com -o get-docker.sh && \


### PR DESCRIPTION
## Overview

See title. This pacakge was removed from [Debian 13 ](https://qa.debian.org/excuses.php?package=software-properties). 

## Testing Instructions

 * Verify that the app builds and runs as expected
